### PR TITLE
feat: shared state store, PubSub event bus, and telemetry

### DIFF
--- a/lib/agent_workshop/pubsub.ex
+++ b/lib/agent_workshop/pubsub.ex
@@ -1,0 +1,121 @@
+defmodule AgentWorkshop.PubSub do
+  @moduledoc """
+  Event bus for agent coordination.
+
+  Agents and processes subscribe to topics and receive messages when
+  events occur. Workshop auto-publishes lifecycle events; you can
+  also publish custom events.
+
+  ## Auto-published events
+
+      {:agent, :ask_complete, agent_name, result}
+      {:agent, :cast_complete, agent_name, result}
+      {:agent, :error, agent_name, reason}
+      {:agent, :created, agent_name}
+      {:agent, :dismissed, agent_name}
+      {:agent, :reset, agent_name}
+      {:store, :put, key}
+      {:store, :delete, key}
+      {:store, :clear}
+
+  ## Usage from IEx
+
+      # Subscribe the current process
+      AgentWorkshop.PubSub.subscribe(:agent_events)
+
+      # Publish a custom event
+      AgentWorkshop.PubSub.broadcast(:deploy_ready, %{sha: "abc123"})
+
+      # Receive (in IEx or a GenServer)
+      receive do
+        {:workshop_event, topic, event} -> IO.inspect(event)
+      end
+
+  ## Usage in agents
+
+  Agents don't subscribe directly (they're CLI subprocesses). Instead,
+  use periodic tasks (#9) or the work board (#16) for reactive patterns.
+  PubSub is primarily for BEAM processes: LiveView dashboards, custom
+  GenServers, telemetry handlers.
+  """
+
+  @registry AgentWorkshop.PubSub.Registry
+
+  @doc """
+  Subscribe the calling process to a topic.
+
+  The process will receive `{:workshop_event, topic, event}` messages.
+  """
+  @spec subscribe(term()) :: :ok
+  def subscribe(topic) do
+    ensure_registry!()
+    Registry.register(@registry, topic, [])
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc """
+  Unsubscribe the calling process from a topic.
+  """
+  @spec unsubscribe(term()) :: :ok
+  def unsubscribe(topic) do
+    ensure_registry!()
+    Registry.unregister(@registry, topic)
+    :ok
+  end
+
+  @doc """
+  Broadcast an event to all subscribers of the `:all` topic
+  and to subscribers of the event's specific topic.
+
+  Events are tuples like `{:agent, :ask_complete, name, result}`.
+  The first element is used as the specific topic.
+  """
+  @spec broadcast(term()) :: :ok
+  def broadcast(event) when is_tuple(event) do
+    topic = elem(event, 0)
+    do_broadcast(topic, event)
+    do_broadcast(:all, event)
+    :ok
+  end
+
+  @doc """
+  Broadcast an event to a specific topic.
+  """
+  @spec broadcast(term(), term()) :: :ok
+  def broadcast(topic, event) do
+    do_broadcast(topic, event)
+    do_broadcast(:all, {:custom, topic, event})
+    :ok
+  end
+
+  @doc false
+  def registry_name, do: @registry
+
+  @doc false
+  def start_registry do
+    case Registry.start_link(keys: :duplicate, name: @registry) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+  end
+
+  defp do_broadcast(topic, event) do
+    if Process.whereis(@registry) do
+      Registry.dispatch(@registry, topic, &dispatch_to_subscribers(&1, topic, event))
+    end
+  end
+
+  defp dispatch_to_subscribers(entries, topic, event) do
+    for {pid, _value} <- entries do
+      send(pid, {:workshop_event, topic, event})
+    end
+  end
+
+  defp ensure_registry! do
+    unless Process.whereis(@registry) do
+      raise "Workshop not started. Call configure/1 first."
+    end
+  end
+end

--- a/lib/agent_workshop/store.ex
+++ b/lib/agent_workshop/store.ex
@@ -1,0 +1,140 @@
+defmodule AgentWorkshop.Store do
+  @moduledoc """
+  Shared key-value store for agent coordination.
+
+  A scratchpad that agents and humans can read and write. Useful for
+  sharing specs, coordination data, accumulated results, and runtime
+  configuration across agents.
+
+  The store is backed by ETS and survives agent resets (it's Workshop-level
+  state, not per-agent). It does not survive Workshop restarts.
+
+  ## From IEx
+
+      import AgentWorkshop.Workshop
+
+      put(:spec, "LRU cache with 1000 entries and 5 min TTL")
+      get(:spec)
+      keys()
+
+  ## From agents (via MCP tools)
+
+  Agents with MCP access can use `workshop_put`, `workshop_get`, `workshop_keys`.
+
+  ## Namespacing
+
+  Keys can be any term. Use tuples for namespacing:
+
+      put({:impl, :notes}, "Chose GenServer over Agent for state")
+      put({:spec, :cache}, "LRU with TTL support")
+      keys()  # => [{:impl, :notes}, {:spec, :cache}]
+  """
+
+  @table :agent_workshop_store
+
+  @doc """
+  Put a value in the store.
+
+  ## Examples
+
+      Store.put(:spec, "Implement LRU cache")
+      Store.put({:impl, :notes}, "Using GenServer")
+  """
+  @spec put(term(), term()) :: :ok
+  def put(key, value) do
+    ensure_table!()
+    :ets.insert(@table, {key, value, System.monotonic_time()})
+    AgentWorkshop.PubSub.broadcast({:store, :put, key})
+    :ok
+  end
+
+  @doc """
+  Get a value from the store. Returns `nil` if not found.
+  """
+  @spec get(term()) :: term() | nil
+  def get(key) do
+    ensure_table!()
+
+    case :ets.lookup(@table, key) do
+      [{^key, value, _ts}] -> value
+      [] -> nil
+    end
+  end
+
+  @doc """
+  Get a value with a default if not found.
+  """
+  @spec get(term(), term()) :: term()
+  def get(key, default) do
+    get(key) || default
+  end
+
+  @doc """
+  List all keys in the store.
+  """
+  @spec keys() :: [term()]
+  def keys do
+    ensure_table!()
+
+    :ets.tab2list(@table)
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.sort()
+  end
+
+  @doc """
+  Delete a key from the store.
+  """
+  @spec delete(term()) :: :ok
+  def delete(key) do
+    ensure_table!()
+    :ets.delete(@table, key)
+    AgentWorkshop.PubSub.broadcast({:store, :delete, key})
+    :ok
+  end
+
+  @doc """
+  Clear all entries from the store.
+  """
+  @spec clear() :: :ok
+  def clear do
+    ensure_table!()
+    :ets.delete_all_objects(@table)
+    AgentWorkshop.PubSub.broadcast({:store, :clear})
+    :ok
+  end
+
+  @doc """
+  List all key-value pairs.
+  """
+  @spec entries() :: [{term(), term()}]
+  def entries do
+    ensure_table!()
+
+    :ets.tab2list(@table)
+    |> Enum.map(fn {key, value, _ts} -> {key, value} end)
+    |> Enum.sort()
+  end
+
+  @doc false
+  def table_name, do: @table
+
+  @doc false
+  def create_table do
+    if :ets.info(@table) == :undefined do
+      :ets.new(@table, [:named_table, :public, :set])
+    end
+  end
+
+  @doc false
+  def delete_table do
+    if :ets.info(@table) != :undefined do
+      :ets.delete(@table)
+    end
+  end
+
+  defp ensure_table! do
+    if :ets.info(@table) == :undefined do
+      raise "Workshop not started. Call configure/1 first."
+    end
+  end
+end

--- a/lib/agent_workshop/telemetry.ex
+++ b/lib/agent_workshop/telemetry.ex
@@ -1,0 +1,101 @@
+defmodule AgentWorkshop.Telemetry do
+  @moduledoc """
+  Telemetry events for Workshop operations.
+
+  All events use the `[:agent_workshop, ...]` prefix. Attach handlers
+  for logging, metrics, cost tracking, or triggering workflows.
+
+  ## Events
+
+      [:agent_workshop, :ask, :start]
+        measurements: %{system_time: integer}
+        metadata: %{agent: atom, prompt: String.t()}
+
+      [:agent_workshop, :ask, :stop]
+        measurements: %{duration: integer, cost: float}
+        metadata: %{agent: atom, prompt: String.t()}
+
+      [:agent_workshop, :ask, :error]
+        measurements: %{duration: integer}
+        metadata: %{agent: atom, prompt: String.t(), error: term}
+
+      [:agent_workshop, :cast, :start]
+        measurements: %{system_time: integer}
+        metadata: %{agent: atom, prompt: String.t()}
+
+      [:agent_workshop, :cast, :complete]
+        measurements: %{duration: integer, cost: float}
+        metadata: %{agent: atom}
+
+      [:agent_workshop, :agent, :created]
+        measurements: %{system_time: integer}
+        metadata: %{agent: atom, role: String.t() | nil, backend: module}
+
+      [:agent_workshop, :agent, :dismissed]
+        measurements: %{system_time: integer}
+        metadata: %{agent: atom}
+
+  ## Example handler
+
+      :telemetry.attach("cost-logger", [:agent_workshop, :ask, :stop], fn
+        _event, %{cost: cost}, %{agent: agent}, _config ->
+          IO.puts("Agent \#{agent} cost $\#{cost}")
+      end, nil)
+  """
+
+  @doc """
+  Emit a telemetry start event. Returns the start time for computing duration.
+  """
+  @spec start(atom(), map()) :: integer()
+  def start(action, metadata \\ %{}) do
+    start_time = System.monotonic_time()
+
+    :telemetry.execute(
+      [:agent_workshop, action, :start],
+      %{system_time: System.system_time()},
+      metadata
+    )
+
+    start_time
+  end
+
+  @doc """
+  Emit a telemetry stop event with duration.
+  """
+  @spec stop(atom(), integer(), map(), map()) :: :ok
+  def stop(action, start_time, measurements \\ %{}, metadata \\ %{}) do
+    duration = System.monotonic_time() - start_time
+
+    :telemetry.execute(
+      [:agent_workshop, action, :stop],
+      Map.merge(%{duration: duration}, measurements),
+      metadata
+    )
+  end
+
+  @doc """
+  Emit a telemetry error event.
+  """
+  @spec error(atom(), integer(), term(), map()) :: :ok
+  def error(action, start_time, error, metadata \\ %{}) do
+    duration = System.monotonic_time() - start_time
+
+    :telemetry.execute(
+      [:agent_workshop, action, :error],
+      %{duration: duration},
+      Map.put(metadata, :error, error)
+    )
+  end
+
+  @doc """
+  Emit a one-shot telemetry event (no start/stop pair).
+  """
+  @spec event(atom(), map(), map()) :: :ok
+  def event(action, measurements \\ %{}, metadata \\ %{}) do
+    :telemetry.execute(
+      [:agent_workshop, action],
+      Map.merge(%{system_time: System.system_time()}, measurements),
+      metadata
+    )
+  end
+end

--- a/lib/agent_workshop/workshop.ex
+++ b/lib/agent_workshop/workshop.ex
@@ -74,6 +74,8 @@ defmodule AgentWorkshop.Workshop do
         `-- Task.Supervisor (async tasks for cast/2)
   """
 
+  alias AgentWorkshop.{PubSub, Store, Telemetry}
+
   @table :agent_workshop_agents
   @state :agent_workshop_state
   @sessions_sup AgentWorkshop.Workshop.SessionsSupervisor
@@ -111,12 +113,16 @@ defmodule AgentWorkshop.Workshop do
         Process.sleep(10)
     end
 
-    # Agent init creates the ETS table so it's owned by a supervised process
+    # Start PubSub registry (before supervisor, so it's available immediately)
+    AgentWorkshop.PubSub.start_registry()
+
+    # Agent init creates ETS tables so they're owned by a supervised process
     agent_init = fn ->
       if :ets.info(@table) == :undefined do
         :ets.new(@table, [:named_table, :public, :set])
       end
 
+      AgentWorkshop.Store.create_table()
       default_state()
     end
 
@@ -153,6 +159,8 @@ defmodule AgentWorkshop.Workshop do
     if :ets.info(@table) != :undefined do
       :ets.delete(@table)
     end
+
+    AgentWorkshop.Store.delete_table()
 
     :ok
   end
@@ -346,6 +354,9 @@ defmodule AgentWorkshop.Workshop do
     }
 
     :ets.insert(@table, {name, entry})
+    global = get_global_state()
+    Telemetry.event(:agent_created, %{}, %{agent: name, role: role, backend: global.backend})
+    PubSub.broadcast({:agent, :created, name})
     :ok
   end
 
@@ -395,6 +406,8 @@ defmodule AgentWorkshop.Workshop do
         end
 
         :ets.delete(@table, name)
+        Telemetry.event(:agent_dismissed, %{}, %{agent: name})
+        PubSub.broadcast({:agent, :dismissed, name})
         :ok
     end
   end
@@ -467,6 +480,7 @@ defmodule AgentWorkshop.Workshop do
     }
 
     :ets.insert(@table, {name, updated})
+    PubSub.broadcast({:agent, :reset, name})
     :ok
   end
 
@@ -567,6 +581,60 @@ defmodule AgentWorkshop.Workshop do
       print_error("MCP server requires anubis_mcp, bandit, and plug deps.")
       {:error, :deps_missing}
     end
+  end
+
+  # ── Shared State ──────────────────────────────────────────────
+
+  @doc """
+  Put a value in the shared store.
+
+  Keys can be any term. Use tuples for namespacing.
+
+  ## Examples
+
+      put(:spec, "LRU cache with TTL support")
+      put({:impl, :notes}, "Chose GenServer over Agent")
+  """
+  defdelegate put(key, value), to: Store
+
+  @doc """
+  Get a value from the shared store. Returns `nil` if not found.
+  """
+  defdelegate get(key), to: Store
+
+  @doc """
+  Get a value with a default.
+  """
+  defdelegate get(key, default), to: Store
+
+  @doc """
+  List all keys in the shared store.
+  """
+  def store_keys, do: Store.keys()
+
+  @doc """
+  Delete a key from the shared store.
+  """
+  defdelegate store_delete(key), to: Store, as: :delete
+
+  @doc """
+  Show all entries in the shared store.
+  """
+  def store do
+    ensure_started()
+
+    case Store.entries() do
+      [] ->
+        print_info("Store is empty.")
+
+      entries ->
+        Enum.each(entries, fn {key, value} ->
+          val_str = inspect(value, limit: 80, printable_limit: 200)
+          IO.puts("  #{inspect(key)}: #{val_str}")
+        end)
+    end
+
+    :ok
   end
 
   # ── Interaction ───────────────────────────────────────────────
@@ -975,9 +1043,14 @@ defmodule AgentWorkshop.Workshop do
 
     IO.puts(IO.ANSI.yellow() <> "#{inspect(name)} working..." <> IO.ANSI.reset())
 
+    start_time = Telemetry.start(:ask, %{agent: name, prompt: prompt})
+
     case entry.backend.send_message(entry.pid, prompt, []) do
       {:ok, result} ->
         cost = result.cost_usd || 0.0
+        Telemetry.stop(:ask, start_time, %{cost: cost}, %{agent: name, prompt: prompt})
+        PubSub.broadcast({:agent, :ask_complete, name, result})
+
         current = get_agent!(name)
 
         update_agent(name, %{
@@ -993,6 +1066,9 @@ defmodule AgentWorkshop.Workshop do
         name
 
       {:error, reason} = err ->
+        Telemetry.error(:ask, start_time, reason, %{agent: name, prompt: prompt})
+        PubSub.broadcast({:agent, :error, name, reason})
+
         current = get_agent!(name)
         update_agent(name, %{current | status: :idle, task_text: nil})
         print_error("#{inspect(name)}: #{inspect(reason)}")
@@ -1006,8 +1082,12 @@ defmodule AgentWorkshop.Workshop do
     backend = entry.backend
     agent_name = name
 
+    Telemetry.start(:cast, %{agent: name, prompt: prompt})
+
     task =
       Task.Supervisor.async_nolink(@tasks_sup, fn ->
+        start_time = System.monotonic_time()
+
         result =
           try do
             backend.send_message(pid, prompt, [])
@@ -1015,7 +1095,7 @@ defmodule AgentWorkshop.Workshop do
             e -> {:error, {:crash, Exception.message(e)}}
           end
 
-        record_async_result(agent_name, result)
+        record_async_result(agent_name, result, start_time)
         result
       end)
 
@@ -1025,7 +1105,11 @@ defmodule AgentWorkshop.Workshop do
 
   # Update ETS with async task result, then drain the queue.
   # Called from within the task process.
-  defp record_async_result(agent_name, {:ok, result}) do
+  defp record_async_result(agent_name, {:ok, result}, start_time) do
+    cost = result.cost_usd || 0.0
+    Telemetry.stop(:cast, start_time, %{cost: cost}, %{agent: agent_name})
+    PubSub.broadcast({:agent, :cast_complete, agent_name, result})
+
     case get_agent(agent_name) do
       nil ->
         :ok
@@ -1034,7 +1118,7 @@ defmodule AgentWorkshop.Workshop do
         update_agent(agent_name, %{
           current
           | status: :idle,
-            cumulative_cost: current.cumulative_cost + (result.cost_usd || 0.0),
+            cumulative_cost: current.cumulative_cost + cost,
             turn_count: current.turn_count + 1,
             last_result: result
         })
@@ -1043,7 +1127,10 @@ defmodule AgentWorkshop.Workshop do
     end
   end
 
-  defp record_async_result(agent_name, {:error, _}) do
+  defp record_async_result(agent_name, {:error, reason}, start_time) do
+    Telemetry.error(:cast, start_time, reason, %{agent: agent_name})
+    PubSub.broadcast({:agent, :error, agent_name, reason})
+
     case get_agent(agent_name) do
       nil ->
         :ok

--- a/mix.exs
+++ b/mix.exs
@@ -25,6 +25,7 @@ defmodule AgentWorkshop.MixProject do
   defp deps do
     [
       {:jason, "~> 1.4"},
+      {:telemetry, "~> 1.2"},
       # Backends -- optional, users pick what they need
       {:claude_wrapper, "~> 0.3", optional: true},
       {:codex_wrapper, "~> 0.2", optional: true},

--- a/test/agent_workshop_test.exs
+++ b/test/agent_workshop_test.exs
@@ -313,4 +313,138 @@ defmodule AgentWorkshop.WorkshopTest do
       end
     end
   end
+
+  describe "shared store" do
+    test "put and get" do
+      setup_mock()
+      Workshop.put(:spec, "LRU cache")
+      assert Workshop.get(:spec) == "LRU cache"
+    end
+
+    test "get returns nil for missing key" do
+      setup_mock()
+      assert Workshop.get(:nonexistent) == nil
+    end
+
+    test "get with default" do
+      setup_mock()
+      assert Workshop.get(:missing, "fallback") == "fallback"
+    end
+
+    test "store_keys lists keys" do
+      setup_mock()
+      Workshop.put(:a, 1)
+      Workshop.put(:b, 2)
+      assert :a in Workshop.store_keys()
+      assert :b in Workshop.store_keys()
+    end
+
+    test "store_delete removes key" do
+      setup_mock()
+      Workshop.put(:temp, "value")
+      Workshop.store_delete(:temp)
+      assert Workshop.get(:temp) == nil
+    end
+
+    test "store shows entries" do
+      setup_mock()
+      Workshop.put(:spec, "cache")
+      assert :ok = Workshop.store()
+    end
+
+    test "namespaced keys" do
+      setup_mock()
+      Workshop.put({:impl, :notes}, "chose GenServer")
+      assert Workshop.get({:impl, :notes}) == "chose GenServer"
+    end
+
+    test "survives agent reset" do
+      setup_mock()
+      Workshop.agent(:impl, "Coder")
+      Workshop.put(:shared, "persists")
+      Workshop.reset(:impl)
+      assert Workshop.get(:shared) == "persists"
+    end
+  end
+
+  describe "pubsub" do
+    test "receives agent created event" do
+      setup_mock()
+      AgentWorkshop.PubSub.subscribe(:agent)
+      Workshop.agent(:impl, "Coder")
+      assert_receive {:workshop_event, :agent, {:agent, :created, :impl}}, 1000
+    end
+
+    test "receives agent dismissed event" do
+      setup_mock()
+      Workshop.agent(:impl, "Coder")
+      AgentWorkshop.PubSub.subscribe(:agent)
+      Workshop.dismiss(:impl)
+      assert_receive {:workshop_event, :agent, {:agent, :dismissed, :impl}}, 1000
+    end
+
+    test "receives ask complete event" do
+      setup_mock()
+      Workshop.agent(:impl, "Coder")
+      AgentWorkshop.PubSub.subscribe(:agent)
+      Workshop.ask(:impl, "hello")
+      assert_receive {:workshop_event, :agent, {:agent, :ask_complete, :impl, _result}}, 1000
+    end
+
+    test "receives store put event" do
+      setup_mock()
+      AgentWorkshop.PubSub.subscribe(:store)
+      Workshop.put(:key, "value")
+      assert_receive {:workshop_event, :store, {:store, :put, :key}}, 1000
+    end
+
+    test ":all topic receives everything" do
+      setup_mock()
+      AgentWorkshop.PubSub.subscribe(:all)
+      Workshop.agent(:impl, "Coder")
+      assert_receive {:workshop_event, :all, {:agent, :created, :impl}}, 1000
+    end
+  end
+
+  describe "telemetry" do
+    test "emits ask start and stop events" do
+      setup_mock()
+
+      ref =
+        :telemetry.attach(
+          "test-ask",
+          [:agent_workshop, :ask, :stop],
+          fn _event, measurements, metadata, _config ->
+            send(self(), {:telemetry, measurements, metadata})
+          end,
+          nil
+        )
+
+      Workshop.agent(:impl, "Coder")
+      Workshop.ask(:impl, "hello")
+
+      assert_receive {:telemetry, %{cost: _cost, duration: _duration}, %{agent: :impl}}, 1000
+
+      :telemetry.detach("test-ask")
+    end
+
+    test "emits agent created event" do
+      setup_mock()
+
+      :telemetry.attach(
+        "test-agent-created",
+        [:agent_workshop, :agent_created],
+        fn _event, _measurements, metadata, _config ->
+          send(self(), {:telemetry_created, metadata})
+        end,
+        nil
+      )
+
+      Workshop.agent(:impl, "Coder")
+
+      assert_receive {:telemetry_created, %{agent: :impl}}, 1000
+
+      :telemetry.detach("test-agent-created")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Layer 1 infrastructure — the foundation everything else builds on.

### Store (#11)
ETS-backed key-value scratchpad for agent coordination.
```elixir
put(:spec, "LRU cache with TTL support")
get(:spec)
store()   # show all entries
```

### PubSub (#10)
Registry-based event bus. Auto-publishes agent lifecycle events.
```elixir
AgentWorkshop.PubSub.subscribe(:agent)
ask(:impl, "hello")
# receive {:workshop_event, :agent, {:agent, :ask_complete, :impl, result}}
```

### Telemetry (#12)
`:telemetry` events on all Workshop operations.
```elixir
:telemetry.attach("cost", [:agent_workshop, :ask, :stop], fn
  _event, %{cost: cost}, %{agent: agent}, _ ->
    IO.puts("#{agent}: $#{cost}")
end, nil)
```

Closes #10, #11, #12

## Test plan

- [x] 39 tests pass (15 new)
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix credo --strict` clean