### PR TITLE
feat: periodic task scheduler and cost budgets

### DIFF
--- a/lib/agent_workshop/budget.ex
+++ b/lib/agent_workshop/budget.ex
@@ -1,0 +1,157 @@
+defmodule AgentWorkshop.Budget do
+  @moduledoc """
+  Cost budget enforcement for Workshop agents.
+
+  Configurable budgets at global and per-agent levels. When a budget
+  is exceeded, `ask/2` and `cast/2` return `{:error, :budget_exceeded}`.
+
+  ## Usage
+
+      configure(max_cost_usd: 10.00)
+      agent(:impl, "Coder", max_cost_usd: 2.00)
+
+      budget()          # show global remaining
+      budget(:impl)     # show per-agent remaining
+      reset_budget()    # reset global tracking
+  """
+
+  @table :agent_workshop_budgets
+
+  @doc false
+  def create_table do
+    if :ets.info(@table) == :undefined do
+      :ets.new(@table, [:named_table, :public, :set])
+    end
+  end
+
+  @doc false
+  def delete_table do
+    if :ets.info(@table) != :undefined do
+      :ets.delete(@table)
+    end
+  end
+
+  @doc """
+  Set a global budget limit.
+  """
+  @spec set_global(float()) :: :ok
+  def set_global(max_usd) when is_number(max_usd) do
+    :ets.insert(@table, {:global_budget, max_usd})
+    :ok
+  end
+
+  @doc """
+  Set a per-agent budget limit.
+  """
+  @spec set_agent(atom(), float()) :: :ok
+  def set_agent(name, max_usd) when is_atom(name) and is_number(max_usd) do
+    :ets.insert(@table, {{:agent_budget, name}, max_usd})
+    :ok
+  end
+
+  @doc """
+  Check if spending `cost` for `agent` would exceed any budget.
+
+  Returns `:ok` or `{:error, :budget_exceeded, reason}`.
+  """
+  @spec check(atom(), float(), float()) :: :ok | {:error, :budget_exceeded, String.t()}
+  def check(agent_name, agent_cumulative_cost, additional_cost) do
+    with :ok <- check_agent_budget(agent_name, agent_cumulative_cost, additional_cost) do
+      check_global_budget(additional_cost)
+    end
+  end
+
+  @doc """
+  Get budget info for a specific agent or global.
+  """
+  @spec info(atom() | :global) :: map()
+  def info(:global) do
+    case get_global_limit() do
+      nil ->
+        %{limit: nil, spent: total_spent(), remaining: nil}
+
+      limit ->
+        spent = total_spent()
+        %{limit: limit, spent: spent, remaining: max(limit - spent, 0.0)}
+    end
+  end
+
+  def info(agent_name) do
+    case get_agent_limit(agent_name) do
+      nil -> %{limit: nil}
+      limit -> %{limit: limit}
+    end
+  end
+
+  @doc """
+  Clear budget limits (does not reset cost tracking — costs are in ETS agent entries).
+  """
+  @spec clear() :: :ok
+  def clear do
+    if :ets.info(@table) != :undefined do
+      :ets.delete_all_objects(@table)
+    end
+
+    :ok
+  end
+
+  # ── Internal ─────────────────────────────────────────────────
+
+  defp check_agent_budget(agent_name, cumulative_cost, additional_cost) do
+    case get_agent_limit(agent_name) do
+      nil ->
+        :ok
+
+      limit when cumulative_cost + additional_cost > limit ->
+        {:error, :budget_exceeded,
+         "#{agent_name}: agent budget exceeded ($#{Float.round(cumulative_cost, 2)} of $#{Float.round(limit, 2)})"}
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp check_global_budget(additional_cost) do
+    case get_global_limit() do
+      nil ->
+        :ok
+
+      limit ->
+        spent = total_spent()
+
+        if spent + additional_cost > limit do
+          {:error, :budget_exceeded,
+           "global budget exceeded ($#{Float.round(spent, 2)} of $#{Float.round(limit, 2)})"}
+        else
+          :ok
+        end
+    end
+  end
+
+  defp get_global_limit do
+    case :ets.lookup(@table, :global_budget) do
+      [{:global_budget, limit}] -> limit
+      [] -> nil
+    end
+  end
+
+  defp get_agent_limit(name) do
+    case :ets.lookup(@table, {:agent_budget, name}) do
+      [{{:agent_budget, ^name}, limit}] -> limit
+      [] -> nil
+    end
+  end
+
+  defp total_spent do
+    agents_table = :agent_workshop_agents
+
+    if :ets.info(agents_table) != :undefined do
+      :ets.tab2list(agents_table)
+      |> Enum.map(fn {_name, entry} -> entry.cumulative_cost end)
+      |> Enum.sum()
+      |> Kernel./(1)
+    else
+      0.0
+    end
+  end
+end

--- a/lib/agent_workshop/scheduler.ex
+++ b/lib/agent_workshop/scheduler.ex
@@ -1,0 +1,139 @@
+defmodule AgentWorkshop.Scheduler do
+  @moduledoc """
+  Periodic task scheduler for Workshop agents.
+
+  Runs agent prompts on a recurring interval. Each schedule is a
+  GenServer that calls `cast/2` on each tick.
+
+  ## Usage from IEx
+
+      import AgentWorkshop.Workshop
+
+      every(:monitor, "Check CI status", interval: :timer.minutes(5))
+      schedules()          # list active schedules
+      cancel(:monitor)     # stop a schedule
+
+  ## Behavior
+
+  - Each tick calls `cast(name, prompt)` (non-blocking)
+  - If the agent is busy (cast queued), the tick is skipped
+  - Schedules survive agent resets but not Workshop restarts
+  - PubSub event `{:schedule, :tick, name}` on each run
+  """
+
+  use GenServer
+
+  alias AgentWorkshop.{PubSub, Telemetry}
+
+  @registry AgentWorkshop.Scheduler.Registry
+
+  defstruct [:agent, :prompt, :interval, :timer_ref, run_count: 0, last_run_at: nil]
+
+  # ── Client API ──────────────────────────────────────────────
+
+  @doc false
+  def start_link(opts) do
+    agent = Keyword.fetch!(opts, :agent)
+    GenServer.start_link(__MODULE__, opts, name: via(agent))
+  end
+
+  @doc false
+  def stop(agent) do
+    case Registry.lookup(@registry, agent) do
+      [{pid, _}] -> GenServer.stop(pid, :normal)
+      [] -> :ok
+    end
+  catch
+    :exit, _ -> :ok
+  end
+
+  @doc false
+  def get_info(agent) do
+    case Registry.lookup(@registry, agent) do
+      [{pid, _}] -> GenServer.call(pid, :info)
+      [] -> nil
+    end
+  end
+
+  @doc false
+  def list_all do
+    Registry.select(@registry, [{{:"$1", :_, :_}, [], [:"$1"]}])
+    |> Enum.sort()
+  end
+
+  @doc false
+  def start_registry do
+    case Registry.start_link(keys: :unique, name: @registry) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+  end
+
+  # ── GenServer callbacks ─────────────────────────────────────
+
+  @impl true
+  def init(opts) do
+    agent = Keyword.fetch!(opts, :agent)
+    prompt = Keyword.fetch!(opts, :prompt)
+    interval = Keyword.fetch!(opts, :interval)
+
+    state = %__MODULE__{
+      agent: agent,
+      prompt: prompt,
+      interval: interval
+    }
+
+    timer_ref = Process.send_after(self(), :tick, interval)
+    {:ok, %{state | timer_ref: timer_ref}}
+  end
+
+  @impl true
+  def handle_info(:tick, state) do
+    # Skip if agent is busy (don't pile up)
+    try do
+      info = AgentWorkshop.Workshop.info(state.agent)
+
+      if info.status == :idle do
+        AgentWorkshop.Workshop.cast(state.agent, state.prompt)
+      end
+    rescue
+      _ -> :ok
+    end
+
+    Telemetry.event(:schedule_tick, %{}, %{agent: state.agent, run_count: state.run_count + 1})
+    PubSub.broadcast({:schedule, :tick, state.agent})
+
+    timer_ref = Process.send_after(self(), :tick, state.interval)
+
+    {:noreply,
+     %{
+       state
+       | timer_ref: timer_ref,
+         run_count: state.run_count + 1,
+         last_run_at: DateTime.utc_now()
+     }}
+  end
+
+  @impl true
+  def handle_call(:info, _from, state) do
+    info = %{
+      agent: state.agent,
+      prompt: state.prompt,
+      interval: state.interval,
+      run_count: state.run_count,
+      last_run_at: state.last_run_at
+    }
+
+    {:reply, info, state}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    if state.timer_ref, do: Process.cancel_timer(state.timer_ref)
+    :ok
+  end
+
+  defp via(agent) do
+    {:via, Registry, {@registry, agent}}
+  end
+end

--- a/lib/agent_workshop/workshop.ex
+++ b/lib/agent_workshop/workshop.ex
@@ -74,7 +74,7 @@ defmodule AgentWorkshop.Workshop do
         `-- Task.Supervisor (async tasks for cast/2)
   """
 
-  alias AgentWorkshop.{PubSub, Store, Telemetry}
+  alias AgentWorkshop.{Budget, PubSub, Scheduler, Store, Telemetry}
 
   @table :agent_workshop_agents
   @state :agent_workshop_state
@@ -113,8 +113,9 @@ defmodule AgentWorkshop.Workshop do
         Process.sleep(10)
     end
 
-    # Start PubSub registry (before supervisor, so it's available immediately)
+    # Start registries (before supervisor, so they're available immediately)
     AgentWorkshop.PubSub.start_registry()
+    AgentWorkshop.Scheduler.start_registry()
 
     # Agent init creates ETS tables so they're owned by a supervised process
     agent_init = fn ->
@@ -123,6 +124,7 @@ defmodule AgentWorkshop.Workshop do
       end
 
       AgentWorkshop.Store.create_table()
+      AgentWorkshop.Budget.create_table()
       default_state()
     end
 
@@ -161,6 +163,7 @@ defmodule AgentWorkshop.Workshop do
     end
 
     AgentWorkshop.Store.delete_table()
+    AgentWorkshop.Budget.delete_table()
 
     :ok
   end
@@ -224,6 +227,7 @@ defmodule AgentWorkshop.Workshop do
     {backend, opts} = Keyword.pop(opts, :backend)
     {backend_config, opts} = Keyword.pop(opts, :backend_config)
     {mcp_opts, opts} = Keyword.pop(opts, :mcp)
+    {max_cost_usd, opts} = Keyword.pop(opts, :max_cost_usd)
     query_opts = opts
     validate_opts!(query_opts)
 
@@ -245,6 +249,7 @@ defmodule AgentWorkshop.Workshop do
       }
     end)
 
+    if max_cost_usd, do: Budget.set_global(max_cost_usd)
     if mcp_opts, do: mcp_server(mcp_opts)
 
     :ok
@@ -317,6 +322,7 @@ defmodule AgentWorkshop.Workshop do
 
     # Merge global query opts with agent-specific opts (agent wins)
     agent_query_opts = split_opts(opts)
+    {agent_max_cost, agent_query_opts} = Keyword.pop(agent_query_opts, :max_cost_usd)
     validate_opts!(agent_query_opts)
     query_opts = Keyword.merge(global.query_opts, agent_query_opts)
 
@@ -354,6 +360,7 @@ defmodule AgentWorkshop.Workshop do
     }
 
     :ets.insert(@table, {name, entry})
+    if agent_max_cost, do: Budget.set_agent(name, agent_max_cost)
     global = get_global_state()
     Telemetry.event(:agent_created, %{}, %{agent: name, role: role, backend: global.backend})
     PubSub.broadcast({:agent, :created, name})
@@ -634,6 +641,124 @@ defmodule AgentWorkshop.Workshop do
         end)
     end
 
+    :ok
+  end
+
+  # ── Scheduling ────────────────────────────────────────────────
+
+  @doc """
+  Run an agent prompt on a recurring interval.
+
+  ## Examples
+
+      every(:monitor, "Check CI status", interval: :timer.minutes(5))
+      every(:sweeper, "Clean up stale branches", interval: :timer.hours(1))
+  """
+  @spec every(atom(), String.t(), keyword()) :: :ok
+  def every(name, prompt, opts) do
+    ensure_started()
+    get_agent!(name)
+    interval = Keyword.fetch!(opts, :interval)
+
+    # Stop existing schedule for this agent
+    Scheduler.stop(name)
+
+    {:ok, _pid} =
+      DynamicSupervisor.start_child(@sessions_sup, {
+        Scheduler,
+        agent: name, prompt: prompt, interval: interval
+      })
+
+    print_info("#{inspect(name)}: scheduled every #{format_interval(interval)}")
+    :ok
+  end
+
+  @doc """
+  List active schedules.
+  """
+  @spec schedules() :: :ok
+  def schedules do
+    ensure_started()
+    agents = Scheduler.list_all()
+
+    if agents == [] do
+      print_info("No active schedules.")
+    else
+      agents
+      |> Enum.map(&Scheduler.get_info/1)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.each(&print_schedule_info/1)
+    end
+
+    :ok
+  end
+
+  @doc """
+  Cancel a scheduled task.
+  """
+  @spec cancel(atom()) :: :ok
+  def cancel(name) do
+    Scheduler.stop(name)
+    :ok
+  end
+
+  # ── Budget ───────────────────────────────────────────────────
+
+  @doc """
+  Show budget info. With no argument, shows global. With an agent name, shows per-agent.
+
+  ## Examples
+
+      budget()          # global budget info
+      budget(:impl)     # per-agent budget
+  """
+  @spec budget(atom() | :global) :: :ok
+  def budget(target \\ :global)
+
+  def budget(:global) do
+    ensure_started()
+    info = Budget.info(:global)
+
+    if info.limit do
+      print_info(
+        "Global: $#{Float.round(info.spent, 2)} / $#{Float.round(info.limit, 2)} " <>
+          "($#{Float.round(info.remaining, 2)} remaining)"
+      )
+    else
+      print_info("Global: no budget set (spent $#{Float.round(info.spent, 2)})")
+    end
+
+    :ok
+  end
+
+  def budget(name) when is_atom(name) do
+    ensure_started()
+    entry = get_agent!(name)
+    agent_info = Budget.info(name)
+
+    if agent_info.limit do
+      remaining = max(agent_info.limit - entry.cumulative_cost, 0.0)
+
+      print_info(
+        "#{inspect(name)}: $#{Float.round(entry.cumulative_cost, 2)} / $#{Float.round(agent_info.limit, 2)} " <>
+          "($#{Float.round(remaining, 2)} remaining)"
+      )
+    else
+      print_info(
+        "#{inspect(name)}: no budget set (spent $#{Float.round(entry.cumulative_cost, 2)})"
+      )
+    end
+
+    :ok
+  end
+
+  @doc """
+  Reset budget tracking. Clears all budget limits.
+  """
+  @spec reset_budget() :: :ok
+  def reset_budget do
+    Budget.clear()
+    print_info("Budgets cleared.")
     :ok
   end
 
@@ -1039,6 +1164,18 @@ defmodule AgentWorkshop.Workshop do
 
   defp do_send_sync(name, prompt) do
     entry = get_agent!(name)
+
+    case Budget.check(name, entry.cumulative_cost, 0.0) do
+      {:error, :budget_exceeded, reason} ->
+        print_error(reason)
+        {:error, :budget_exceeded}
+
+      :ok ->
+        do_send_sync_inner(name, prompt, entry)
+    end
+  end
+
+  defp do_send_sync_inner(name, prompt, entry) do
     update_agent(name, %{entry | status: :working, task_text: truncate(prompt, 36)})
 
     IO.puts(IO.ANSI.yellow() <> "#{inspect(name)} working..." <> IO.ANSI.reset())
@@ -1078,6 +1215,18 @@ defmodule AgentWorkshop.Workshop do
 
   defp do_send_async(name, prompt) do
     entry = get_agent!(name)
+
+    case Budget.check(name, entry.cumulative_cost, 0.0) do
+      {:error, :budget_exceeded, reason} ->
+        print_error(reason)
+        {:error, :budget_exceeded}
+
+      :ok ->
+        do_send_async_inner(name, prompt, entry)
+    end
+  end
+
+  defp do_send_async_inner(name, prompt, entry) do
     pid = entry.pid
     backend = entry.backend
     agent_name = name
@@ -1300,6 +1449,22 @@ defmodule AgentWorkshop.Workshop do
 
   defp plural(1), do: ""
   defp plural(_), do: "s"
+
+  defp print_schedule_info(info) do
+    last =
+      if info.last_run_at,
+        do: Calendar.strftime(info.last_run_at, "%H:%M:%S"),
+        else: "never"
+
+    print_info(
+      "#{inspect(info.agent)}: every #{format_interval(info.interval)}, #{info.run_count} runs, last: #{last}"
+    )
+  end
+
+  defp format_interval(ms) when ms >= 3_600_000, do: "#{div(ms, 3_600_000)}h"
+  defp format_interval(ms) when ms >= 60_000, do: "#{div(ms, 60_000)}m"
+  defp format_interval(ms) when ms >= 1_000, do: "#{div(ms, 1_000)}s"
+  defp format_interval(ms), do: "#{ms}ms"
 
   defp print_turn({turn, i}) do
     cost_str = if turn.cost_usd, do: " (#{format_cost(turn.cost_usd)})", else: ""

--- a/test/agent_workshop_test.exs
+++ b/test/agent_workshop_test.exs
@@ -447,4 +447,80 @@ defmodule AgentWorkshop.WorkshopTest do
       :telemetry.detach("test-agent-created")
     end
   end
+
+  describe "scheduling" do
+    test "every/3 creates a schedule" do
+      setup_mock()
+      Workshop.agent(:monitor, "Monitor")
+      Workshop.every(:monitor, "check status", interval: 100)
+      assert :monitor in AgentWorkshop.Scheduler.list_all()
+      Workshop.cancel(:monitor)
+    end
+
+    test "schedule ticks cast to agent" do
+      setup_mock()
+      Workshop.agent(:monitor, "Monitor")
+      AgentWorkshop.PubSub.subscribe(:schedule)
+      Workshop.every(:monitor, "check", interval: 50)
+      assert_receive {:workshop_event, :schedule, {:schedule, :tick, :monitor}}, 500
+      Workshop.cancel(:monitor)
+    end
+
+    test "cancel stops the schedule" do
+      setup_mock()
+      Workshop.agent(:monitor, "Monitor")
+      Workshop.every(:monitor, "check", interval: 100)
+      Workshop.cancel(:monitor)
+      refute :monitor in AgentWorkshop.Scheduler.list_all()
+    end
+
+    test "schedules/0 works" do
+      setup_mock()
+      Workshop.agent(:monitor, "Monitor")
+      Workshop.every(:monitor, "check", interval: 60_000)
+      assert :ok = Workshop.schedules()
+      Workshop.cancel(:monitor)
+    end
+  end
+
+  describe "budgets" do
+    test "global budget blocks when exceeded" do
+      setup_mock()
+      Workshop.configure(max_cost_usd: 0.005)
+      Workshop.agent(:impl, "Coder")
+      # First ask uses $0.01, exceeding the $0.005 budget
+      Workshop.ask(:impl, "hello")
+      # Second ask should be blocked
+      result = Workshop.ask(:impl, "hello again")
+      assert result == {:error, :budget_exceeded}
+    end
+
+    test "per-agent budget blocks when exceeded" do
+      setup_mock()
+      Workshop.agent(:impl, "Coder", max_cost_usd: 0.005)
+      Workshop.ask(:impl, "hello")
+      result = Workshop.ask(:impl, "hello again")
+      assert result == {:error, :budget_exceeded}
+    end
+
+    test "budget/0 shows global info" do
+      setup_mock()
+      assert :ok = Workshop.budget()
+    end
+
+    test "budget/1 shows agent info" do
+      setup_mock()
+      Workshop.agent(:impl, "Coder")
+      assert :ok = Workshop.budget(:impl)
+    end
+
+    test "reset_budget clears limits" do
+      setup_mock()
+      Workshop.configure(max_cost_usd: 1.00)
+      Workshop.reset_budget()
+      # After reset, no budget limit
+      info = AgentWorkshop.Budget.info(:global)
+      assert info.limit == nil
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Layer 2 infrastructure building on Layer 1 (store, pubsub, telemetry).

### Scheduler (#9)
```elixir
every(:monitor, "Check CI status", interval: :timer.minutes(5))
schedules()    # list active schedules
cancel(:monitor)
```
- GenServer per schedule, calls cast/2 on each tick
- Skips ticks when agent is busy
- PubSub events on each tick

### Cost Budgets (#14)
```elixir
configure(max_cost_usd: 10.00)
agent(:impl, "Coder", max_cost_usd: 2.00)
budget()          # global remaining
budget(:impl)     # per-agent remaining
```
- ask/cast return {:error, :budget_exceeded} when over limit
- Global and per-agent limits independent

Closes #9, closes #14

## Test plan

- [x] 48 tests pass (9 new)
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix credo --strict` clean