### PR TITLE
feat: work board with lifecycle, dependencies, and agent claiming

### DIFF
--- a/lib/agent_workshop/work.ex
+++ b/lib/agent_workshop/work.ex
@@ -1,0 +1,353 @@
+defmodule AgentWorkshop.Work do
+  @moduledoc """
+  Work board for agent coordination.
+
+  A structured task tracker where work items flow through a lifecycle.
+  Agents poll for work matching their role, claim it, and advance it
+  through states. Dependencies between items handle ordering.
+
+  ## Work item lifecycle
+
+      new → ready → claimed → in_progress → done
+                                           → failed
+                         ↑
+                   blocked (unmet dependency)
+                   cancelled
+
+  ## Usage from IEx
+
+      import AgentWorkshop.Workshop
+
+      # Add work
+      work(:cache, "Implement LRU cache",
+        type: :code, spec: "LRU with 1000 entries and TTL")
+      work(:cache_review, "Review cache implementation",
+        type: :review, depends_on: [:cache])
+      work(:cache_tests, "Write cache tests",
+        type: :test, depends_on: [:cache])
+
+      # Browse
+      board()                    # full board
+      board(status: :ready)      # items ready to pick up
+      board(type: :code)         # only code tasks
+
+      # Work on items
+      claim(:cache, :impl)      # agent claims the task
+      start_work(:cache)        # mark in progress
+      complete(:cache)          # mark done, unblocks dependents
+      fail(:cache, "tests broke")
+
+  ## Agent polling
+
+  Agents check the board for work matching their type:
+
+      every(:coder, "Check board(type: :code, status: :ready) and work on one item",
+        interval: :timer.minutes(2))
+  """
+
+  alias AgentWorkshop.{PubSub, Telemetry}
+
+  @table :agent_workshop_work
+  @valid_statuses [:new, :ready, :claimed, :in_progress, :done, :failed, :blocked, :cancelled]
+  @valid_types [:code, :review, :test, :docs, :deploy, :triage, :custom]
+
+  defstruct [
+    :id,
+    :title,
+    :spec,
+    :type,
+    :claimed_by,
+    :result,
+    :error,
+    :created_at,
+    :completed_at,
+    status: :new,
+    priority: 3,
+    depends_on: []
+  ]
+
+  @type t :: %__MODULE__{
+          id: atom(),
+          title: String.t(),
+          spec: String.t() | nil,
+          type: atom(),
+          status: atom(),
+          priority: non_neg_integer(),
+          depends_on: [atom()],
+          claimed_by: atom() | nil,
+          result: String.t() | nil,
+          error: String.t() | nil,
+          created_at: DateTime.t(),
+          completed_at: DateTime.t() | nil
+        }
+
+  # ── Table management ────────────────────────────────────────
+
+  @doc false
+  def create_table do
+    if :ets.info(@table) == :undefined do
+      :ets.new(@table, [:named_table, :public, :set])
+    end
+  end
+
+  @doc false
+  def delete_table do
+    if :ets.info(@table) != :undefined do
+      :ets.delete(@table)
+    end
+  end
+
+  # ── CRUD ────────────────────────────────────────────────────
+
+  @doc """
+  Add a work item to the board.
+  """
+  @spec add(atom(), String.t(), keyword()) :: :ok
+  def add(id, title, opts \\ []) do
+    type = Keyword.get(opts, :type, :custom)
+    spec = Keyword.get(opts, :spec)
+    priority = Keyword.get(opts, :priority, 3)
+    depends_on = Keyword.get(opts, :depends_on, [])
+
+    item = %__MODULE__{
+      id: id,
+      title: title,
+      spec: spec,
+      type: type,
+      priority: priority,
+      depends_on: depends_on,
+      created_at: DateTime.utc_now()
+    }
+
+    # Set initial status based on dependencies
+    item = resolve_status(item)
+
+    :ets.insert(@table, {id, item})
+    Telemetry.event(:work_added, %{}, %{id: id, type: type})
+    PubSub.broadcast({:work, :added, id})
+    :ok
+  end
+
+  @doc """
+  Get a work item by ID.
+  """
+  @spec get(atom()) :: t() | nil
+  def get(id) do
+    case :ets.lookup(@table, id) do
+      [{^id, item}] -> item
+      [] -> nil
+    end
+  end
+
+  @doc """
+  List work items, optionally filtered.
+  """
+  @spec list(keyword()) :: [t()]
+  def list(filters \\ []) do
+    :ets.tab2list(@table)
+    |> Enum.map(&elem(&1, 1))
+    |> apply_filters(filters)
+    |> Enum.sort_by(fn item -> {item.priority, item.created_at} end)
+  end
+
+  @doc """
+  Claim a work item for an agent.
+  """
+  @spec claim(atom(), atom()) :: :ok | {:error, term()}
+  def claim(id, agent_name) do
+    case get(id) do
+      nil ->
+        {:error, :not_found}
+
+      %{status: :ready} = item ->
+        update(id, %{item | status: :claimed, claimed_by: agent_name})
+        PubSub.broadcast({:work, :claimed, id, agent_name})
+        :ok
+
+      %{status: status} ->
+        {:error, {:invalid_transition, status, :claimed}}
+    end
+  end
+
+  @doc """
+  Mark a work item as in progress.
+  """
+  @spec start_work(atom()) :: :ok | {:error, term()}
+  def start_work(id) do
+    case get(id) do
+      nil ->
+        {:error, :not_found}
+
+      %{status: :claimed} = item ->
+        update(id, %{item | status: :in_progress})
+        PubSub.broadcast({:work, :started, id})
+        :ok
+
+      %{status: status} ->
+        {:error, {:invalid_transition, status, :in_progress}}
+    end
+  end
+
+  @doc """
+  Mark a work item as done. Unblocks dependents.
+  """
+  @spec complete(atom(), String.t() | nil) :: :ok | {:error, term()}
+  def complete(id, result \\ nil) do
+    case get(id) do
+      nil ->
+        {:error, :not_found}
+
+      %{status: status} = item when status in [:claimed, :in_progress] ->
+        update(id, %{item | status: :done, result: result, completed_at: DateTime.utc_now()})
+        Telemetry.event(:work_completed, %{}, %{id: id, type: item.type})
+        PubSub.broadcast({:work, :completed, id})
+        unblock_dependents(id)
+        :ok
+
+      %{status: status} ->
+        {:error, {:invalid_transition, status, :done}}
+    end
+  end
+
+  @doc """
+  Mark a work item as failed.
+  """
+  @spec fail(atom(), String.t() | nil) :: :ok | {:error, term()}
+  def fail(id, error \\ nil) do
+    case get(id) do
+      nil ->
+        {:error, :not_found}
+
+      %{status: status} = item when status in [:claimed, :in_progress] ->
+        update(id, %{item | status: :failed, error: error, completed_at: DateTime.utc_now()})
+        Telemetry.event(:work_failed, %{}, %{id: id, type: item.type, error: error})
+        PubSub.broadcast({:work, :failed, id})
+        block_dependents(id)
+        :ok
+
+      %{status: status} ->
+        {:error, {:invalid_transition, status, :failed}}
+    end
+  end
+
+  @doc """
+  Cancel a work item.
+  """
+  @spec cancel(atom()) :: :ok | {:error, term()}
+  def cancel(id) do
+    case get(id) do
+      nil ->
+        {:error, :not_found}
+
+      %{status: :done} ->
+        {:error, :already_done}
+
+      item ->
+        update(id, %{item | status: :cancelled, completed_at: DateTime.utc_now()})
+        PubSub.broadcast({:work, :cancelled, id})
+        block_dependents(id)
+        :ok
+    end
+  end
+
+  @doc """
+  Remove a work item from the board entirely.
+  """
+  @spec remove(atom()) :: :ok
+  def remove(id) do
+    :ets.delete(@table, id)
+    :ok
+  end
+
+  @doc """
+  Clear all work items.
+  """
+  @spec clear() :: :ok
+  def clear do
+    if :ets.info(@table) != :undefined do
+      :ets.delete_all_objects(@table)
+    end
+
+    :ok
+  end
+
+  @doc """
+  Summary counts by status.
+  """
+  @spec summary() :: map()
+  def summary do
+    list()
+    |> Enum.group_by(& &1.status)
+    |> Enum.map(fn {status, items} -> {status, length(items)} end)
+    |> Map.new()
+  end
+
+  @doc false
+  def valid_statuses, do: @valid_statuses
+
+  @doc false
+  def valid_types, do: @valid_types
+
+  # ── Internal ────────────────────────────────────────────────
+
+  defp update(id, item) do
+    :ets.insert(@table, {id, item})
+  end
+
+  defp resolve_status(item) do
+    if item.depends_on == [] or all_deps_done?(item.depends_on) do
+      %{item | status: :ready}
+    else
+      %{item | status: :new}
+    end
+  end
+
+  defp all_deps_done?(dep_ids) do
+    Enum.all?(dep_ids, fn dep_id ->
+      case get(dep_id) do
+        %{status: :done} -> true
+        _ -> false
+      end
+    end)
+  end
+
+  defp unblock_dependents(completed_id) do
+    list()
+    |> Enum.filter(fn item ->
+      completed_id in item.depends_on and item.status in [:new, :blocked]
+    end)
+    |> Enum.each(fn item ->
+      if all_deps_done?(item.depends_on) do
+        update(item.id, %{item | status: :ready})
+        PubSub.broadcast({:work, :ready, item.id})
+      end
+    end)
+  end
+
+  defp block_dependents(failed_id) do
+    list()
+    |> Enum.filter(fn item ->
+      failed_id in item.depends_on and item.status in [:new, :ready]
+    end)
+    |> Enum.each(fn item ->
+      update(item.id, %{item | status: :blocked})
+      PubSub.broadcast({:work, :blocked, item.id})
+    end)
+  end
+
+  defp apply_filters(items, []), do: items
+
+  defp apply_filters(items, [{:status, status} | rest]) do
+    items |> Enum.filter(&(&1.status == status)) |> apply_filters(rest)
+  end
+
+  defp apply_filters(items, [{:type, type} | rest]) do
+    items |> Enum.filter(&(&1.type == type)) |> apply_filters(rest)
+  end
+
+  defp apply_filters(items, [{:claimed_by, agent} | rest]) do
+    items |> Enum.filter(&(&1.claimed_by == agent)) |> apply_filters(rest)
+  end
+
+  defp apply_filters(items, [_ | rest]), do: apply_filters(items, rest)
+end

--- a/lib/agent_workshop/workshop.ex
+++ b/lib/agent_workshop/workshop.ex
@@ -74,7 +74,7 @@ defmodule AgentWorkshop.Workshop do
         `-- Task.Supervisor (async tasks for cast/2)
   """
 
-  alias AgentWorkshop.{Budget, PubSub, Scheduler, Store, Telemetry}
+  alias AgentWorkshop.{Budget, PubSub, Scheduler, Store, Telemetry, Work}
 
   @table :agent_workshop_agents
   @state :agent_workshop_state
@@ -125,6 +125,7 @@ defmodule AgentWorkshop.Workshop do
 
       AgentWorkshop.Store.create_table()
       AgentWorkshop.Budget.create_table()
+      AgentWorkshop.Work.create_table()
       default_state()
     end
 
@@ -164,6 +165,7 @@ defmodule AgentWorkshop.Workshop do
 
     AgentWorkshop.Store.delete_table()
     AgentWorkshop.Budget.delete_table()
+    AgentWorkshop.Work.delete_table()
 
     :ok
   end
@@ -760,6 +762,168 @@ defmodule AgentWorkshop.Workshop do
     Budget.clear()
     print_info("Budgets cleared.")
     :ok
+  end
+
+  # ── Work Board ────────────────────────────────────────────────
+
+  @doc """
+  Add a work item to the board.
+
+  ## Options
+
+    * `:type` - work type (`:code`, `:review`, `:test`, `:docs`, `:deploy`, `:triage`, `:custom`)
+    * `:spec` - detailed specification
+    * `:priority` - 1 (highest) to 5 (lowest), default 3
+    * `:depends_on` - list of work item IDs that must complete first
+
+  ## Examples
+
+      work(:cache, "Implement LRU cache",
+        type: :code, priority: 1,
+        spec: "LRU cache with configurable max size and TTL per entry")
+
+      work(:cache_review, "Review cache implementation",
+        type: :review, depends_on: [:cache])
+  """
+  @spec work(atom(), String.t(), keyword()) :: :ok
+  def work(id, title, opts \\ []) do
+    ensure_started()
+    Work.add(id, title, opts)
+  end
+
+  @doc """
+  Show the work board. Optionally filter by status or type.
+
+  ## Examples
+
+      board()                    # full board
+      board(status: :ready)      # items ready to pick up
+      board(type: :code)         # only code tasks
+  """
+  @spec board(keyword()) :: :ok
+  def board(filters \\ []) do
+    ensure_started()
+    items = Work.list(filters)
+
+    if items == [] do
+      print_info("Board is empty.")
+    else
+      Enum.each(items, &print_work_item/1)
+
+      summary = Work.summary()
+      parts = Enum.map_join(summary, ", ", fn {status, count} -> "#{status}: #{count}" end)
+      print_info(parts)
+    end
+
+    :ok
+  end
+
+  @doc """
+  Claim a work item for an agent.
+
+  ## Example
+
+      claim(:cache, :impl)
+  """
+  @spec claim_work(atom(), atom()) :: :ok | {:error, term()}
+  def claim_work(id, agent_name) do
+    ensure_started()
+    get_agent!(agent_name)
+
+    case Work.claim(id, agent_name) do
+      :ok ->
+        print_info("#{inspect(agent_name)} claimed #{inspect(id)}")
+        :ok
+
+      {:error, reason} ->
+        print_error("Cannot claim #{inspect(id)}: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Mark a work item as in progress.
+  """
+  @spec start_work(atom()) :: :ok | {:error, term()}
+  def start_work(id) do
+    ensure_started()
+
+    case Work.start_work(id) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        print_error("Cannot start #{inspect(id)}: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Mark a work item as done. Unblocks any dependents.
+
+  ## Examples
+
+      complete_work(:cache)
+      complete_work(:cache, "Implemented with GenServer-backed LRU")
+  """
+  @spec complete_work(atom(), String.t() | nil) :: :ok | {:error, term()}
+  def complete_work(id, result \\ nil) do
+    ensure_started()
+
+    case Work.complete(id, result) do
+      :ok ->
+        print_info("#{inspect(id)} done.")
+        :ok
+
+      {:error, reason} ->
+        print_error("Cannot complete #{inspect(id)}: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Mark a work item as failed.
+  """
+  @spec fail_work(atom(), String.t() | nil) :: :ok | {:error, term()}
+  def fail_work(id, error \\ nil) do
+    ensure_started()
+
+    case Work.fail(id, error) do
+      :ok ->
+        print_error("#{inspect(id)} failed: #{error || "no reason"}")
+        :ok
+
+      {:error, reason} ->
+        print_error("Cannot fail #{inspect(id)}: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Cancel a work item.
+  """
+  @spec cancel_work(atom()) :: :ok | {:error, term()}
+  def cancel_work(id) do
+    ensure_started()
+
+    case Work.cancel(id) do
+      :ok ->
+        print_info("#{inspect(id)} cancelled.")
+        :ok
+
+      {:error, reason} ->
+        print_error("Cannot cancel #{inspect(id)}: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Get details of a specific work item.
+  """
+  @spec work_item(atom()) :: Work.t() | nil
+  def work_item(id) do
+    ensure_started()
+    Work.get(id)
   end
 
   # ── Interaction ───────────────────────────────────────────────
@@ -1449,6 +1613,27 @@ defmodule AgentWorkshop.Workshop do
 
   defp plural(1), do: ""
   defp plural(_), do: "s"
+
+  defp print_work_item(item) do
+    status_color =
+      case item.status do
+        :done -> IO.ANSI.green()
+        :failed -> IO.ANSI.red()
+        :in_progress -> IO.ANSI.yellow()
+        :ready -> IO.ANSI.cyan()
+        :blocked -> IO.ANSI.light_black()
+        _ -> ""
+      end
+
+    claimed = if item.claimed_by, do: " (#{item.claimed_by})", else: ""
+    deps = if item.depends_on != [], do: " deps: #{inspect(item.depends_on)}", else: ""
+
+    IO.puts(
+      "  #{status_color}[#{item.status}]#{IO.ANSI.reset()} " <>
+        "#{inspect(item.id)} - #{item.title}" <>
+        " [#{item.type}]#{claimed}#{deps}"
+    )
+  end
 
   defp print_schedule_info(info) do
     last =

--- a/test/agent_workshop_test.exs
+++ b/test/agent_workshop_test.exs
@@ -523,4 +523,158 @@ defmodule AgentWorkshop.WorkshopTest do
       assert info.limit == nil
     end
   end
+
+  describe "work board" do
+    test "add and list work items" do
+      setup_mock()
+      Workshop.work(:cache, "Implement cache", type: :code)
+      Workshop.work(:tests, "Write tests", type: :test)
+      items = AgentWorkshop.Work.list()
+      assert length(items) == 2
+    end
+
+    test "items without deps start as ready" do
+      setup_mock()
+      Workshop.work(:cache, "Implement cache", type: :code)
+      item = Workshop.work_item(:cache)
+      assert item.status == :ready
+    end
+
+    test "items with unmet deps start as new" do
+      setup_mock()
+      Workshop.work(:cache, "Implement cache", type: :code)
+      Workshop.work(:review, "Review cache", type: :review, depends_on: [:cache])
+      item = Workshop.work_item(:review)
+      assert item.status == :new
+    end
+
+    test "completing a dep unblocks dependents" do
+      setup_mock()
+      Workshop.agent(:impl, "Coder")
+      Workshop.work(:cache, "Implement cache", type: :code)
+      Workshop.work(:review, "Review cache", type: :review, depends_on: [:cache])
+
+      assert Workshop.work_item(:review).status == :new
+
+      Workshop.claim_work(:cache, :impl)
+      Workshop.start_work(:cache)
+      Workshop.complete_work(:cache)
+
+      assert Workshop.work_item(:review).status == :ready
+    end
+
+    test "claim and start workflow" do
+      setup_mock()
+      Workshop.agent(:impl, "Coder")
+      Workshop.work(:cache, "Implement cache", type: :code)
+
+      assert :ok = Workshop.claim_work(:cache, :impl)
+      assert Workshop.work_item(:cache).claimed_by == :impl
+      assert Workshop.work_item(:cache).status == :claimed
+
+      assert :ok = Workshop.start_work(:cache)
+      assert Workshop.work_item(:cache).status == :in_progress
+    end
+
+    test "complete sets done and timestamp" do
+      setup_mock()
+      Workshop.agent(:impl, "Coder")
+      Workshop.work(:cache, "Implement cache", type: :code)
+      Workshop.claim_work(:cache, :impl)
+      Workshop.complete_work(:cache, "Done with GenServer")
+
+      item = Workshop.work_item(:cache)
+      assert item.status == :done
+      assert item.result == "Done with GenServer"
+      assert item.completed_at != nil
+    end
+
+    test "fail blocks dependents" do
+      setup_mock()
+      Workshop.agent(:impl, "Coder")
+      Workshop.work(:cache, "Implement cache", type: :code)
+      Workshop.work(:review, "Review", type: :review, depends_on: [:cache])
+
+      Workshop.claim_work(:cache, :impl)
+      Workshop.fail_work(:cache, "tests broken")
+
+      assert Workshop.work_item(:cache).status == :failed
+      assert Workshop.work_item(:review).status == :blocked
+    end
+
+    test "cancel work" do
+      setup_mock()
+      Workshop.work(:cache, "Implement cache", type: :code)
+      Workshop.cancel_work(:cache)
+      assert Workshop.work_item(:cache).status == :cancelled
+    end
+
+    test "filter by status" do
+      setup_mock()
+      Workshop.work(:a, "Task A", type: :code)
+      Workshop.work(:b, "Task B", type: :code)
+      Workshop.work(:c, "Task C", type: :review, depends_on: [:a])
+
+      ready = AgentWorkshop.Work.list(status: :ready)
+      assert length(ready) == 2
+      assert Enum.all?(ready, &(&1.status == :ready))
+    end
+
+    test "filter by type" do
+      setup_mock()
+      Workshop.work(:a, "Code task", type: :code)
+      Workshop.work(:b, "Review task", type: :review)
+
+      code_items = AgentWorkshop.Work.list(type: :code)
+      assert length(code_items) == 1
+      assert hd(code_items).type == :code
+    end
+
+    test "board display works" do
+      setup_mock()
+      Workshop.work(:cache, "Implement cache", type: :code)
+      assert :ok = Workshop.board()
+    end
+
+    test "board display with empty board" do
+      setup_mock()
+      assert :ok = Workshop.board()
+    end
+
+    test "priority ordering" do
+      setup_mock()
+      Workshop.work(:low, "Low priority", type: :code, priority: 5)
+      Workshop.work(:high, "High priority", type: :code, priority: 1)
+      Workshop.work(:mid, "Mid priority", type: :code, priority: 3)
+
+      items = AgentWorkshop.Work.list()
+      assert Enum.map(items, & &1.id) == [:high, :mid, :low]
+    end
+
+    test "pubsub events on work state changes" do
+      setup_mock()
+      Workshop.agent(:impl, "Coder")
+      AgentWorkshop.PubSub.subscribe(:work)
+
+      Workshop.work(:cache, "Implement cache", type: :code)
+      assert_receive {:workshop_event, :work, {:work, :added, :cache}}, 1000
+
+      Workshop.claim_work(:cache, :impl)
+      assert_receive {:workshop_event, :work, {:work, :claimed, :cache, :impl}}, 1000
+
+      Workshop.complete_work(:cache)
+      assert_receive {:workshop_event, :work, {:work, :completed, :cache}}, 1000
+    end
+
+    test "summary counts" do
+      setup_mock()
+      Workshop.work(:a, "A", type: :code)
+      Workshop.work(:b, "B", type: :code)
+      Workshop.work(:c, "C", type: :review, depends_on: [:a])
+
+      summary = AgentWorkshop.Work.summary()
+      assert summary[:ready] == 2
+      assert summary[:new] == 1
+    end
+  end
 end


### PR DESCRIPTION
## Summary

The big one. A structured work board where items flow through a lifecycle and agents self-organize around available work.

### Lifecycle

```
new → ready → claimed → in_progress → done
                                     → failed
              blocked (unmet deps)
              cancelled
```

### Usage

```elixir
# Add work with dependencies
work(:cache, "Implement LRU cache", type: :code, priority: 1,
  spec: "LRU with configurable max size and TTL")
work(:cache_review, "Review cache", type: :review, depends_on: [:cache])
work(:cache_tests, "Write tests", type: :test, depends_on: [:cache])

# Browse
board()                    # full board
board(status: :ready)      # available work
board(type: :code)         # code tasks only

# Agents claim and advance work
claim_work(:cache, :impl)
start_work(:cache)
complete_work(:cache, "Done with GenServer")
# :cache_review and :cache_tests auto-unblock to :ready
```

### Features

- Dependency graph with automatic unblocking
- Failed/cancelled items cascade-block dependents
- Priority ordering (1=highest)
- PubSub events on all transitions
- Telemetry on add/complete/fail
- Filtered listing (status, type, claimed_by)

Closes #16

## Test plan

- [x] 63 tests pass (15 new)
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix credo --strict` clean