### PR TITLE
feat: workshop_tools, profiles, and work board MCP tools

### DIFF
--- a/lib/agent_workshop/mcp.ex
+++ b/lib/agent_workshop/mcp.ex
@@ -391,6 +391,159 @@ if Code.ensure_loaded?(Anubis.Server) do
     end
   end
 
+  # ── Work Board Tools ─────────────────────────────────────────
+
+  defmodule AgentWorkshop.MCP.Tools.AddWork do
+    @moduledoc false
+    use Anubis.Server.Component, type: :tool
+    alias Anubis.Server.Response
+
+    schema do
+      field(:id, :string, required: true, description: "work item ID")
+      field(:title, :string, required: true, description: "work item title")
+      field(:type, :string, description: "work type: code, review, test, docs, deploy, triage")
+      field(:spec, :string, description: "detailed specification")
+      field(:priority, :integer, description: "1 (highest) to 5 (lowest), default 3")
+      field(:depends_on, {:list, :string}, description: "list of work item IDs to depend on")
+    end
+
+    @impl true
+    def execute(%{id: id, title: title} = params, frame) do
+      opts =
+        params
+        |> Map.drop([:id, :title])
+        |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+        |> Enum.map(fn
+          {:type, v} -> {:type, String.to_existing_atom(v)}
+          {:depends_on, ids} -> {:depends_on, Enum.map(ids, &String.to_atom/1)}
+          pair -> pair
+        end)
+
+      AgentWorkshop.Workshop.work(String.to_atom(id), title, opts)
+      {:reply, Response.text(Response.tool(), "Work item #{id} added."), frame}
+    end
+  end
+
+  defmodule AgentWorkshop.MCP.Tools.Board do
+    @moduledoc false
+    use Anubis.Server.Component, type: :tool
+    alias Anubis.Server.Response
+
+    schema do
+      field(:status, :string,
+        description: "filter by status: new, ready, claimed, in_progress, done, failed, blocked"
+      )
+
+      field(:type, :string, description: "filter by type: code, review, test, docs")
+    end
+
+    @impl true
+    def execute(params, frame) do
+      filters =
+        params
+        |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+        |> Enum.map(fn {k, v} -> {k, String.to_existing_atom(v)} end)
+
+      text = format_board(AgentWorkshop.Work.list(filters))
+      {:reply, Response.text(Response.tool(), text), frame}
+    end
+
+    defp format_board([]), do: "Board is empty."
+
+    defp format_board(items) do
+      Enum.map_join(items, "\n", fn item ->
+        claimed = if item.claimed_by, do: " (#{item.claimed_by})", else: ""
+        deps = if item.depends_on != [], do: " deps:#{inspect(item.depends_on)}", else: ""
+        "[#{item.status}] #{item.id} - #{item.title} [#{item.type}]#{claimed}#{deps}"
+      end)
+    end
+  end
+
+  defmodule AgentWorkshop.MCP.Tools.ClaimWork do
+    @moduledoc false
+    use Anubis.Server.Component, type: :tool
+    alias Anubis.Server.Response
+
+    schema do
+      field(:id, :string, required: true, description: "work item ID to claim")
+      field(:agent, :string, required: true, description: "agent name claiming the work")
+    end
+
+    @impl true
+    def execute(%{id: id, agent: agent}, frame) do
+      case AgentWorkshop.Work.claim(String.to_existing_atom(id), String.to_existing_atom(agent)) do
+        :ok -> {:reply, Response.text(Response.tool(), "#{agent} claimed #{id}."), frame}
+        {:error, reason} -> {:reply, Response.error(Response.tool(), inspect(reason)), frame}
+      end
+    end
+  end
+
+  defmodule AgentWorkshop.MCP.Tools.CompleteWork do
+    @moduledoc false
+    use Anubis.Server.Component, type: :tool
+    alias Anubis.Server.Response
+
+    schema do
+      field(:id, :string, required: true, description: "work item ID to complete")
+      field(:result, :string, description: "result summary")
+    end
+
+    @impl true
+    def execute(%{id: id} = params, frame) do
+      result = Map.get(params, :result)
+
+      case AgentWorkshop.Work.complete(String.to_existing_atom(id), result) do
+        :ok -> {:reply, Response.text(Response.tool(), "#{id} completed."), frame}
+        {:error, reason} -> {:reply, Response.error(Response.tool(), inspect(reason)), frame}
+      end
+    end
+  end
+
+  defmodule AgentWorkshop.MCP.Tools.FailWork do
+    @moduledoc false
+    use Anubis.Server.Component, type: :tool
+    alias Anubis.Server.Response
+
+    schema do
+      field(:id, :string, required: true, description: "work item ID that failed")
+      field(:error, :string, description: "error description")
+    end
+
+    @impl true
+    def execute(%{id: id} = params, frame) do
+      error = Map.get(params, :error)
+
+      case AgentWorkshop.Work.fail(String.to_existing_atom(id), error) do
+        :ok -> {:reply, Response.text(Response.tool(), "#{id} marked as failed."), frame}
+        {:error, reason} -> {:reply, Response.error(Response.tool(), inspect(reason)), frame}
+      end
+    end
+  end
+
+  defmodule AgentWorkshop.MCP.Tools.FromProfile do
+    @moduledoc false
+    use Anubis.Server.Component, type: :tool
+    alias Anubis.Server.Response
+
+    schema do
+      field(:profile, :string, required: true, description: "profile name to instantiate")
+      field(:name, :string, required: true, description: "name for the new agent")
+    end
+
+    @impl true
+    def execute(%{profile: profile, name: name}, frame) do
+      AgentWorkshop.Workshop.from_profile(
+        String.to_existing_atom(profile),
+        String.to_atom(name)
+      )
+
+      {:reply, Response.text(Response.tool(), "Agent #{name} created from profile #{profile}."),
+       frame}
+    rescue
+      e -> {:reply, Response.error(Response.tool(), Exception.message(e)), frame}
+    end
+  end
+
   # ── Server ──────────────────────────────────────────────────
 
   defmodule AgentWorkshop.MCP.Server do
@@ -421,6 +574,12 @@ if Code.ensure_loaded?(Anubis.Server) do
     component(AgentWorkshop.MCP.Tools.Reset)
     component(AgentWorkshop.MCP.Tools.Dismiss)
     component(AgentWorkshop.MCP.Tools.Cost)
+    component(AgentWorkshop.MCP.Tools.AddWork)
+    component(AgentWorkshop.MCP.Tools.Board)
+    component(AgentWorkshop.MCP.Tools.ClaimWork)
+    component(AgentWorkshop.MCP.Tools.CompleteWork)
+    component(AgentWorkshop.MCP.Tools.FailWork)
+    component(AgentWorkshop.MCP.Tools.FromProfile)
 
     @impl true
     def init(_client_info, frame) do
@@ -519,6 +678,7 @@ if Code.ensure_loaded?(Anubis.Server) do
       end
 
       :persistent_term.put({__MODULE__, :request_timeout}, request_timeout)
+      :persistent_term.put({__MODULE__, :port}, port)
 
       children = [
         {AgentWorkshop.MCP.Server,

--- a/lib/agent_workshop/profiles.ex
+++ b/lib/agent_workshop/profiles.ex
@@ -1,0 +1,88 @@
+defmodule AgentWorkshop.Profiles do
+  @moduledoc """
+  Reusable agent templates.
+
+  Define profiles once, instantiate agents from them on demand.
+  Useful for orchestrators that spin up ephemeral agents for specific tasks.
+
+  ## Usage
+
+      profile(:coder, "You write clean code.", max_turns: 15)
+      profile(:reviewer, "Review only.", model: "opus", allowed_tools: ["Read", "Bash"])
+
+      # Create an agent from a profile
+      from_profile(:coder, :coder_bug_42)
+
+      # List available profiles
+      profiles()
+  """
+
+  @table :agent_workshop_profiles
+
+  @type profile_def :: %{role: String.t() | nil, opts: keyword()}
+
+  @doc false
+  def create_table do
+    if :ets.info(@table) == :undefined do
+      :ets.new(@table, [:named_table, :public, :set])
+    end
+  end
+
+  @doc false
+  def delete_table do
+    if :ets.info(@table) != :undefined do
+      :ets.delete(@table)
+    end
+  end
+
+  @doc """
+  Define a profile.
+  """
+  @spec define(atom(), String.t() | nil, keyword()) :: :ok
+  def define(name, role \\ nil, opts \\ []) do
+    :ets.insert(@table, {name, %{role: role, opts: opts}})
+    :ok
+  end
+
+  @doc """
+  Get a profile definition.
+  """
+  @spec get(atom()) :: profile_def() | nil
+  def get(name) do
+    case :ets.lookup(@table, name) do
+      [{^name, definition}] -> definition
+      [] -> nil
+    end
+  end
+
+  @doc """
+  List all profile names.
+  """
+  @spec list() :: [atom()]
+  def list do
+    :ets.tab2list(@table)
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.sort()
+  end
+
+  @doc """
+  Remove a profile.
+  """
+  @spec remove(atom()) :: :ok
+  def remove(name) do
+    :ets.delete(@table, name)
+    :ok
+  end
+
+  @doc """
+  Clear all profiles.
+  """
+  @spec clear() :: :ok
+  def clear do
+    if :ets.info(@table) != :undefined do
+      :ets.delete_all_objects(@table)
+    end
+
+    :ok
+  end
+end

--- a/lib/agent_workshop/workshop.ex
+++ b/lib/agent_workshop/workshop.ex
@@ -74,7 +74,7 @@ defmodule AgentWorkshop.Workshop do
         `-- Task.Supervisor (async tasks for cast/2)
   """
 
-  alias AgentWorkshop.{Budget, PubSub, Scheduler, Store, Telemetry, Work}
+  alias AgentWorkshop.{Budget, Profiles, PubSub, Scheduler, Store, Telemetry, Work}
 
   @table :agent_workshop_agents
   @state :agent_workshop_state
@@ -82,7 +82,7 @@ defmodule AgentWorkshop.Workshop do
   @tasks_sup AgentWorkshop.Workshop.TasksSupervisor
   @supervisor AgentWorkshop.Workshop.Supervisor
 
-  @special_keys [:backend, :backend_config, :context]
+  @special_keys [:backend, :backend_config, :context, :workshop_tools, :max_cost_usd]
   @max_queue_size 5
   @valid_permission_modes [:default, :accept_edits, :bypass_permissions, :dont_ask, :plan, :auto]
 
@@ -126,6 +126,7 @@ defmodule AgentWorkshop.Workshop do
       AgentWorkshop.Store.create_table()
       AgentWorkshop.Budget.create_table()
       AgentWorkshop.Work.create_table()
+      AgentWorkshop.Profiles.create_table()
       default_state()
     end
 
@@ -166,6 +167,7 @@ defmodule AgentWorkshop.Workshop do
     AgentWorkshop.Store.delete_table()
     AgentWorkshop.Budget.delete_table()
     AgentWorkshop.Work.delete_table()
+    AgentWorkshop.Profiles.delete_table()
 
     :ok
   end
@@ -322,11 +324,26 @@ defmodule AgentWorkshop.Workshop do
     # Compose system prompt: global context + agent role
     system_prompt = compose_system_prompt(global.context, role)
 
+    # Extract special opts
+    {workshop_tools, opts} = Keyword.pop(opts, :workshop_tools, false)
+    {agent_max_cost, opts} = Keyword.pop(opts, :max_cost_usd)
+
     # Merge global query opts with agent-specific opts (agent wins)
     agent_query_opts = split_opts(opts)
-    {agent_max_cost, agent_query_opts} = Keyword.pop(agent_query_opts, :max_cost_usd)
     validate_opts!(agent_query_opts)
     query_opts = Keyword.merge(global.query_opts, agent_query_opts)
+
+    # If workshop_tools: true, inject MCP config so agent can orchestrate
+    query_opts =
+      if workshop_tools do
+        mcp_path = write_workshop_mcp_config()
+
+        Keyword.update(query_opts, :mcp_config, [mcp_path], fn paths ->
+          paths ++ [mcp_path]
+        end)
+      else
+        query_opts
+      end
 
     query_opts =
       if system_prompt do
@@ -761,6 +778,66 @@ defmodule AgentWorkshop.Workshop do
   def reset_budget do
     Budget.clear()
     print_info("Budgets cleared.")
+    :ok
+  end
+
+  # ── Profiles ──────────────────────────────────────────────────
+
+  @doc """
+  Define a reusable agent profile (template).
+
+  ## Examples
+
+      profile(:coder, "You write clean code.", max_turns: 15)
+      profile(:reviewer, "Review only.", model: "opus", allowed_tools: ["Read", "Bash"])
+  """
+  @spec profile(atom(), String.t() | nil, keyword()) :: :ok
+  def profile(name, role \\ nil, opts \\ []) do
+    ensure_started()
+    Profiles.define(name, role, opts)
+  end
+
+  @doc """
+  Create an agent from a profile.
+
+  ## Examples
+
+      profile(:coder, "You write code.", max_turns: 15)
+      from_profile(:coder, :coder_bug_42)
+      from_profile(:coder, :coder_feature_7, max_turns: 25)  # override opts
+  """
+  @spec from_profile(atom(), atom(), keyword()) :: :ok
+  def from_profile(profile_name, agent_name, overrides \\ []) do
+    ensure_started()
+
+    case Profiles.get(profile_name) do
+      nil ->
+        raise ArgumentError,
+              "unknown profile #{inspect(profile_name)}. Define it with profile/3."
+
+      %{role: role, opts: base_opts} ->
+        merged_opts = Keyword.merge(base_opts, overrides)
+        agent(agent_name, role, merged_opts)
+    end
+  end
+
+  @doc """
+  List available profiles.
+  """
+  @spec profiles() :: :ok
+  def profiles do
+    ensure_started()
+    names = Profiles.list()
+
+    if names == [] do
+      print_info("No profiles defined.")
+    else
+      names
+      |> Enum.map(&{&1, Profiles.get(&1)})
+      |> Enum.reject(fn {_, v} -> is_nil(v) end)
+      |> Enum.each(&print_profile/1)
+    end
+
     :ok
   end
 
@@ -1541,6 +1618,28 @@ defmodule AgentWorkshop.Workshop do
     :ets.insert(@table, {name, entry})
   end
 
+  defp write_workshop_mcp_config do
+    port =
+      if Code.ensure_loaded?(AgentWorkshop.MCP) do
+        :persistent_term.get({AgentWorkshop.MCP, :port}, 4222)
+      else
+        4222
+      end
+
+    config = %{
+      "mcpServers" => %{
+        "workshop" => %{
+          "type" => "http",
+          "url" => "http://localhost:#{port}/mcp"
+        }
+      }
+    }
+
+    path = Path.join(System.tmp_dir!(), "workshop_mcp_#{:erlang.phash2(self())}.json")
+    File.write!(path, Jason.encode!(config))
+    path
+  end
+
   # ── Internal: Helpers ─────────────────────────────────────────
 
   defp split_opts(opts) do
@@ -1613,6 +1712,11 @@ defmodule AgentWorkshop.Workshop do
 
   defp plural(1), do: ""
   defp plural(_), do: "s"
+
+  defp print_profile({name, %{role: role, opts: opts}}) do
+    model = Keyword.get(opts, :model, "default")
+    print_info("#{inspect(name)}: #{role || "(no role)"} [#{model}]")
+  end
 
   defp print_work_item(item) do
     status_color =

--- a/test/agent_workshop_test.exs
+++ b/test/agent_workshop_test.exs
@@ -677,4 +677,48 @@ defmodule AgentWorkshop.WorkshopTest do
       assert summary[:new] == 1
     end
   end
+
+  describe "profiles" do
+    test "define and list profiles" do
+      setup_mock()
+      Workshop.profile(:coder, "You write code.", max_turns: 15)
+      Workshop.profile(:reviewer, "Review only.", model: "opus")
+      assert :ok = Workshop.profiles()
+      assert :coder in AgentWorkshop.Profiles.list()
+      assert :reviewer in AgentWorkshop.Profiles.list()
+    end
+
+    test "from_profile creates agent" do
+      setup_mock()
+      Workshop.profile(:coder, "You write code.", max_turns: 15)
+      Workshop.from_profile(:coder, :coder_42)
+      assert :coder_42 in Workshop.agents()
+    end
+
+    test "from_profile with overrides" do
+      setup_mock()
+      Workshop.profile(:coder, "You write code.", model: "sonnet")
+      Workshop.from_profile(:coder, :coder_opus, model: "opus")
+      info = Workshop.info(:coder_opus)
+      assert info.model == "opus"
+    end
+
+    test "from_profile raises for unknown profile" do
+      setup_mock()
+
+      assert_raise ArgumentError, ~r/unknown profile/, fn ->
+        Workshop.from_profile(:nonexistent, :agent)
+      end
+    end
+  end
+
+  describe "workshop_tools" do
+    test "workshop_tools option adds mcp_config to query_opts" do
+      setup_mock()
+      Workshop.agent(:orchestrator, "Coordinator", workshop_tools: true)
+      entry = Workshop.info(:orchestrator)
+      # The mcp_config should be in the query_opts (not visible in info, but agent was created)
+      assert :orchestrator in Workshop.agents()
+    end
+  end
 end


### PR DESCRIPTION
## Summary

The missing pieces for the autonomous demo. Agents can now orchestrate other agents, use profiles for ephemeral workers, and interact with the work board — all via MCP tools.

### workshop_tools (#7)
```elixir
agent(:orchestrator, "You coordinate a team.",
  workshop_tools: true, model: "opus", max_turns: 25)
ask(:orchestrator, "Break down and implement the caching feature")
```
Agent gets a temp .mcp.json with all Workshop tools.

### Profiles (#4)
```elixir
profile(:coder, "You write clean code.", max_turns: 15)
profile(:reviewer, "Review only.", model: "opus")
from_profile(:coder, :coder_bug_42)
```

### Work board MCP tools (6 new tools)
- `add_work` — create items with type, spec, priority, deps
- `board` — list/filter by status and type
- `claim_work` — agent claims a ready item
- `complete_work` — mark done, unblocks dependents
- `fail_work` — mark failed, blocks dependents
- `from_profile` — create agent from template

### MCP session fix (#8)
Already fixed — request_timeout flows through to Plug.

Closes #4, #7, #8

## Test plan

- [x] 68 tests pass (5 new)
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix credo --strict` clean