### PR TITLE
feat: event log with live watch and history

### DIFF
--- a/lib/agent_workshop/event_log.ex
+++ b/lib/agent_workshop/event_log.ex
@@ -1,0 +1,216 @@
+defmodule AgentWorkshop.EventLog do
+  @moduledoc """
+  Event history and live streaming for Workshop operations.
+
+  Subscribes to PubSub and stores events in a ring buffer. Optionally
+  prints events live to the console as they happen.
+
+  ## Usage from IEx
+
+      watch()              # start printing live events
+      unwatch()            # stop printing
+      events()             # show last 20 events
+      events(last: 50)     # show more
+      clear_events()       # clear history
+  """
+
+  use GenServer
+
+  alias AgentWorkshop.PubSub
+
+  @name __MODULE__
+  @default_max_events 500
+
+  defstruct events: :queue.new(),
+            count: 0,
+            max_events: @default_max_events,
+            watching: false,
+            watch_pid: nil
+
+  # ── Client API ──────────────────────────────────────────────
+
+  @doc false
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: @name)
+  end
+
+  @doc """
+  Start printing live events to the console.
+  """
+  @spec watch() :: :ok
+  def watch do
+    GenServer.call(@name, {:watch, self()})
+  end
+
+  @doc """
+  Stop printing live events.
+  """
+  @spec unwatch() :: :ok
+  def unwatch do
+    GenServer.call(@name, :unwatch)
+  end
+
+  @doc """
+  Get recent events.
+  """
+  @spec recent(keyword()) :: [map()]
+  def recent(opts \\ []) do
+    limit = Keyword.get(opts, :last, 20)
+    GenServer.call(@name, {:recent, limit})
+  end
+
+  @doc """
+  Clear event history.
+  """
+  @spec clear() :: :ok
+  def clear do
+    GenServer.call(@name, :clear)
+  end
+
+  @doc """
+  Is live watching enabled?
+  """
+  @spec watching?() :: boolean()
+  def watching? do
+    GenServer.call(@name, :watching?)
+  end
+
+  # ── GenServer callbacks ─────────────────────────────────────
+
+  @impl true
+  def init(opts) do
+    max = Keyword.get(opts, :max_events, @default_max_events)
+    PubSub.subscribe(:all)
+
+    {:ok, %__MODULE__{max_events: max}}
+  end
+
+  @impl true
+  def handle_call({:watch, pid}, _from, state) do
+    {:reply, :ok, %{state | watching: true, watch_pid: pid}}
+  end
+
+  def handle_call(:unwatch, _from, state) do
+    {:reply, :ok, %{state | watching: false, watch_pid: nil}}
+  end
+
+  def handle_call({:recent, limit}, _from, state) do
+    events =
+      state.events
+      |> :queue.to_list()
+      |> Enum.take(-limit)
+
+    {:reply, events, state}
+  end
+
+  def handle_call(:clear, _from, state) do
+    {:reply, :ok, %{state | events: :queue.new(), count: 0}}
+  end
+
+  def handle_call(:watching?, _from, state) do
+    {:reply, state.watching, state}
+  end
+
+  @impl true
+  def handle_info({:workshop_event, _topic, event}, state) do
+    entry = %{
+      event: event,
+      timestamp: DateTime.utc_now(),
+      formatted: format_event(event)
+    }
+
+    # Print live if watching
+    if state.watching and entry.formatted do
+      IO.puts(IO.ANSI.light_black() <> entry.formatted <> IO.ANSI.reset())
+    end
+
+    # Store in ring buffer
+    events = :queue.in(entry, state.events)
+    count = state.count + 1
+
+    {events, count} =
+      if count > state.max_events do
+        {:queue.drop(events), count - 1}
+      else
+        {events, count}
+      end
+
+    {:noreply, %{state | events: events, count: count}}
+  end
+
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  # ── Event formatting ────────────────────────────────────────
+
+  defp format_event({:agent, :created, name}) do
+    "[agent] #{name} created"
+  end
+
+  defp format_event({:agent, :dismissed, name}) do
+    "[agent] #{name} dismissed"
+  end
+
+  defp format_event({:agent, :reset, name}) do
+    "[agent] #{name} reset"
+  end
+
+  defp format_event({:agent, :ask_complete, name, result}) do
+    cost = format_cost(result[:cost_usd])
+    text = truncate(result[:result] || "", 60)
+    "[ask] #{name} complete #{cost} — #{text}"
+  end
+
+  defp format_event({:agent, :cast_complete, name, result}) do
+    cost = format_cost(result[:cost_usd])
+    text = truncate(result[:result] || "", 60)
+    "[cast] #{name} complete #{cost} — #{text}"
+  end
+
+  defp format_event({:agent, :error, name, reason}) do
+    "[error] #{name}: #{inspect(reason)}"
+  end
+
+  defp format_event({:store, :put, key}) do
+    "[store] put #{inspect(key)}"
+  end
+
+  defp format_event({:store, :delete, key}) do
+    "[store] delete #{inspect(key)}"
+  end
+
+  defp format_event({:store, :clear}) do
+    "[store] cleared"
+  end
+
+  defp format_event({:work, action, id}) when is_atom(action) do
+    "[work] #{id} #{action}"
+  end
+
+  defp format_event({:work, :claimed, id, agent}) do
+    "[work] #{id} claimed by #{agent}"
+  end
+
+  defp format_event({:schedule, :tick, name}) do
+    "[tick] #{name}"
+  end
+
+  defp format_event({:custom, topic, _data}) do
+    "[event] #{inspect(topic)}"
+  end
+
+  defp format_event(_), do: nil
+
+  defp format_cost(nil), do: ""
+  defp format_cost(cost) when is_number(cost), do: "($#{Float.round(cost / 1, 2)})"
+  defp format_cost(_), do: ""
+
+  defp truncate(str, max) do
+    if String.length(str) > max do
+      String.slice(str, 0, max - 3) <> "..."
+    else
+      str
+    end
+  end
+end

--- a/lib/agent_workshop/workshop.ex
+++ b/lib/agent_workshop/workshop.ex
@@ -133,7 +133,8 @@ defmodule AgentWorkshop.Workshop do
     children = [
       %{id: @state, start: {Agent, :start_link, [agent_init, [name: @state]]}},
       {DynamicSupervisor, name: @sessions_sup, strategy: :one_for_one},
-      {Task.Supervisor, name: @tasks_sup}
+      {Task.Supervisor, name: @tasks_sup},
+      AgentWorkshop.EventLog
     ]
 
     case Supervisor.start_link(children, strategy: :one_for_one, name: @supervisor) do
@@ -660,6 +661,75 @@ defmodule AgentWorkshop.Workshop do
         end)
     end
 
+    :ok
+  end
+
+  # ── Event Log ─────────────────────────────────────────────────
+
+  @doc """
+  Start printing live events to the console.
+
+  Shows agent creation/dismissal, ask/cast completions with cost,
+  work board changes, errors, and more.
+
+  ## Example
+
+      watch()
+      cast(:impl, "do something")
+      # [agent] impl created
+      # [cast] impl complete ($0.04) — Here is the implementation...
+  """
+  @spec watch() :: :ok
+  def watch do
+    AgentWorkshop.EventLog.watch()
+    print_info("Watching events. Use unwatch() to stop.")
+    :ok
+  end
+
+  @doc """
+  Stop printing live events.
+  """
+  @spec unwatch() :: :ok
+  def unwatch do
+    AgentWorkshop.EventLog.unwatch()
+    print_info("Stopped watching.")
+    :ok
+  end
+
+  @doc """
+  Show recent events.
+
+  ## Options
+
+    * `:last` - number of events to show (default 20)
+
+  ## Examples
+
+      events()            # last 20
+      events(last: 50)    # last 50
+  """
+  @spec events(keyword()) :: :ok
+  def events(opts \\ []) do
+    ensure_started()
+    entries = AgentWorkshop.EventLog.recent(opts)
+
+    if entries == [] do
+      print_info("No events recorded.")
+    else
+      entries
+      |> Enum.filter(& &1.formatted)
+      |> Enum.each(&print_event/1)
+    end
+
+    :ok
+  end
+
+  @doc """
+  Clear event history.
+  """
+  @spec clear_events() :: :ok
+  def clear_events do
+    AgentWorkshop.EventLog.clear()
     :ok
   end
 
@@ -1712,6 +1782,11 @@ defmodule AgentWorkshop.Workshop do
 
   defp plural(1), do: ""
   defp plural(_), do: "s"
+
+  defp print_event(entry) do
+    time = Calendar.strftime(entry.timestamp, "%H:%M:%S")
+    IO.puts(IO.ANSI.light_black() <> "#{time} #{entry.formatted}" <> IO.ANSI.reset())
+  end
 
   defp print_profile({name, %{role: role, opts: opts}}) do
     model = Keyword.get(opts, :model, "default")

--- a/test/agent_workshop_test.exs
+++ b/test/agent_workshop_test.exs
@@ -448,6 +448,41 @@ defmodule AgentWorkshop.WorkshopTest do
     end
   end
 
+  describe "event log" do
+    test "records agent events" do
+      setup_mock()
+      Workshop.agent(:impl, "Coder")
+      Workshop.ask(:impl, "hello")
+
+      entries = AgentWorkshop.EventLog.recent()
+      formatted = Enum.map(entries, & &1.formatted) |> Enum.reject(&is_nil/1)
+
+      assert Enum.any?(formatted, &String.contains?(&1, "impl created"))
+      assert Enum.any?(formatted, &String.contains?(&1, "impl complete"))
+    end
+
+    test "watch and unwatch" do
+      setup_mock()
+      assert :ok = Workshop.watch()
+      assert AgentWorkshop.EventLog.watching?()
+      assert :ok = Workshop.unwatch()
+      refute AgentWorkshop.EventLog.watching?()
+    end
+
+    test "events/0 displays" do
+      setup_mock()
+      Workshop.agent(:impl, "Coder")
+      assert :ok = Workshop.events()
+    end
+
+    test "clear_events/0 clears" do
+      setup_mock()
+      Workshop.agent(:impl, "Coder")
+      Workshop.clear_events()
+      assert AgentWorkshop.EventLog.recent() == []
+    end
+  end
+
   describe "scheduling" do
     test "every/3 creates a schedule" do
       setup_mock()


### PR DESCRIPTION
## Summary

See what's happening inside Workshop while agents work.

### Live watching
```elixir
watch()
cast(:orchestrator, "build the thing")
# 10:23:41 [agent] coder_status created
# 10:23:45 [ask] coder_status complete ($0.12) — Here is the implementation...
# 10:24:02 [agent] reviewer created
# 10:24:15 [ask] reviewer complete ($0.24) — The implementation looks solid...
# 10:24:16 [agent] coder_status dismissed
# 10:24:16 [agent] reviewer dismissed
```

### Event history
```elixir
events()            # last 20 events with timestamps
events(last: 50)    # more
clear_events()
```

Stores up to 500 events in a ring buffer. Formats agent lifecycle, ask/cast completions with cost, work board changes, errors, and schedule ticks.

## Test plan

- [x] 72 tests pass (4 new)
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix credo --strict` clean