### PR TITLE
fix: event log visible on dark terminals

### DIFF
--- a/lib/agent_workshop/event_log.ex
+++ b/lib/agent_workshop/event_log.ex
@@ -126,7 +126,7 @@ defmodule AgentWorkshop.EventLog do
 
     # Print live if watching
     if state.watching and entry.formatted do
-      IO.puts(IO.ANSI.light_black() <> entry.formatted <> IO.ANSI.reset())
+      IO.puts(IO.ANSI.cyan() <> entry.formatted <> IO.ANSI.reset())
     end
 
     # Store in ring buffer

--- a/lib/agent_workshop/workshop.ex
+++ b/lib/agent_workshop/workshop.ex
@@ -1785,7 +1785,7 @@ defmodule AgentWorkshop.Workshop do
 
   defp print_event(entry) do
     time = Calendar.strftime(entry.timestamp, "%H:%M:%S")
-    IO.puts(IO.ANSI.light_black() <> "#{time} #{entry.formatted}" <> IO.ANSI.reset())
+    IO.puts(IO.ANSI.cyan() <> "#{time} #{entry.formatted}" <> IO.ANSI.reset())
   end
 
   defp print_profile({name, %{role: role, opts: opts}}) do


### PR DESCRIPTION
light_black is invisible on dark terminal backgrounds. Switch to cyan.