### PR TITLE
fix: info/1 non-blocking (fixes await_all MCP crash)

### DIFF
--- a/lib/agent_workshop/workshop.ex
+++ b/lib/agent_workshop/workshop.ex
@@ -1382,7 +1382,14 @@ defmodule AgentWorkshop.Workshop do
   def info(name) do
     ensure_started()
     entry = get_agent!(name)
-    session_id = entry.backend.session_id(entry.pid)
+
+    # Pull session_id from last result if available.
+    # Do NOT call backend.session_id — it blocks if the agent is busy.
+    session_id =
+      case entry.last_result do
+        %{session_id: sid} -> sid
+        _ -> nil
+      end
 
     %{
       name: name,


### PR DESCRIPTION
info/1 was calling backend.session_id(pid) which blocks when the agent
is busy. This crashed await_all over MCP during the orchestration demo.

Now reads session_id from last_result in ETS — never blocks.

Fixes #28