### PR TITLE
feat: skills directory, AGENTS.md, and auto-injection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# Agent Workshop
+
+Multi-agent orchestration for software development. You coordinate teams of AI agents that build, review, and test code.
+
+## How it works
+
+Workshop runs in an Elixir IEx session or via MCP tools. Agents are named processes backed by LLM CLIs (Claude, Codex, etc.). You create agents, give them roles, and coordinate their work.
+
+## Key concepts
+
+- **Agent**: a named, role-specific LLM session. Created with `agent(:name, "role")` or `from_profile(:profile, :name)`.
+- **Profile**: a reusable agent template. Defined with `profile(:coder, "role", opts)`.
+- **Work board**: structured task tracker with lifecycle (new, ready, claimed, in_progress, done, failed, blocked).
+- **Store**: shared key-value scratchpad agents can read/write.
+
+## If you are an orchestrator agent
+
+You have access to Workshop MCP tools. Your job is to coordinate, not to write code yourself.
+
+**You MUST delegate work using Workshop tools.** Do not write code directly.
+
+### Your workflow
+
+1. **Plan**: break the task into discrete units
+2. **Create agents**: use `from_profile` to create specialist agents (coders, reviewers, testers)
+3. **Delegate**: use `ask` for synchronous work, `cast` for parallel work
+4. **Review**: create a reviewer agent to check the work
+5. **Fix**: send review feedback back to coders
+6. **Clean up**: dismiss ephemeral agents when done
+
+### Available tools
+
+| Tool | Use for |
+|---|---|
+| `from_profile` | Create an agent from a template |
+| `ask` | Send a message and wait for response |
+| `cast` | Send a message asynchronously (parallel work) |
+| `await` / `await_all` | Wait for async agents to finish |
+| `status` | Check which agents are busy/idle |
+| `result` | Get an agent's last response |
+| `pipe` | Send one agent's output to another |
+| `dismiss` | Remove an agent when done |
+| `add_work` | Add items to the work board |
+| `board` | View work items |
+| `claim_work` / `complete_work` | Manage work lifecycle |
+
+### Patterns
+
+- **Parallel coders**: create multiple coders, `cast` different tasks to each, `await_all`
+- **Review loop**: `ask` coder, then `ask` reviewer, then `ask` coder with feedback
+- **Specialization**: create coders for specific areas (`:coder_tests`, `:coder_api`, `:coder_docs`)
+
+### Rules
+
+- Do not write code yourself. Always delegate to a coder agent.
+- Do not skip review. Always create a reviewer.
+- Name agents descriptively: `:coder_status`, `:coder_auth`, not `:agent1`.
+- Dismiss agents when their work is done.
+- Report a summary when all work is complete.
+
+## If you are a coder agent
+
+You write code. Focus on the task you're given. Write tests alongside implementation. Run `mix test` (or equivalent) before reporting completion.
+
+## If you are a reviewer agent
+
+You review code for correctness, edge cases, and style. Do not modify files. Report findings as a prioritized, actionable list.
+
+## Available skills
+
+See the `skills/` directory for detailed pattern guides:
+- `solo/` — single agent, direct interaction
+- `pair/` — implement + review via pipe
+- `board/` — work board driven, agents poll by role
+- `orchestrator/` — coordinator with workshop_tools
+- `monitor/` — scheduled agent for periodic checks
+- `mixed/` — multiple backends (Claude + Codex)

--- a/lib/agent_workshop/skills.ex
+++ b/lib/agent_workshop/skills.ex
@@ -1,0 +1,94 @@
+defmodule AgentWorkshop.Skills do
+  @moduledoc """
+  Loads skill content and AGENTS.md for injection into agent system prompts.
+
+  Skills are markdown files following the agentskills.io format, stored
+  in the `skills/` directory of the agent_workshop package.
+
+  AGENTS.md provides top-level context for any agent with Workshop tools.
+  """
+
+  @doc """
+  Load the AGENTS.md content from the package.
+  """
+  @spec agents_md() :: String.t() | nil
+  def agents_md do
+    load_file("AGENTS.md")
+  end
+
+  @doc """
+  Load a skill's SKILL.md content by name.
+  """
+  @spec skill(atom()) :: String.t() | nil
+  def skill(name) do
+    load_file(Path.join(["skills", to_string(name), "SKILL.md"]))
+  end
+
+  @doc """
+  List available skill names.
+  """
+  @spec list() :: [atom()]
+  def list do
+    skills_dir = Path.join(package_root(), "skills")
+
+    if File.dir?(skills_dir) do
+      skills_dir
+      |> File.ls!()
+      |> Enum.filter(fn name ->
+        dir = Path.join(skills_dir, name)
+        File.dir?(dir) and File.exists?(Path.join(dir, "SKILL.md"))
+      end)
+      |> Enum.map(&String.to_atom/1)
+      |> Enum.sort()
+    else
+      []
+    end
+  end
+
+  @doc """
+  Build context string for an agent based on its role.
+
+  For `workshop_tools: true` agents, includes the orchestrator section
+  from AGENTS.md. For agents with a `:skill` option, includes that
+  skill's content.
+  """
+  @spec context_for(keyword()) :: String.t() | nil
+  def context_for(opts) do
+    workshop_tools = Keyword.get(opts, :workshop_tools, false)
+    skill_name = Keyword.get(opts, :skill)
+
+    parts =
+      [
+        if(workshop_tools, do: agents_md()),
+        if(skill_name, do: skill(skill_name))
+      ]
+      |> Enum.reject(&is_nil/1)
+
+    case parts do
+      [] -> nil
+      parts -> Enum.join(parts, "\n\n---\n\n")
+    end
+  end
+
+  # ── Internal ────────────────────────────────────────────────
+
+  defp load_file(relative_path) do
+    path = Path.join(package_root(), relative_path)
+
+    case File.read(path) do
+      {:ok, content} -> content
+      {:error, _} -> nil
+    end
+  end
+
+  defp package_root do
+    # Try the project root first (development), then the compiled app path
+    project_root = Path.join([__DIR__, "..", ".."]) |> Path.expand()
+
+    if File.exists?(Path.join(project_root, "AGENTS.md")) do
+      project_root
+    else
+      Application.app_dir(:agent_workshop)
+    end
+  end
+end

--- a/lib/agent_workshop/workshop.ex
+++ b/lib/agent_workshop/workshop.ex
@@ -82,7 +82,7 @@ defmodule AgentWorkshop.Workshop do
   @tasks_sup AgentWorkshop.Workshop.TasksSupervisor
   @supervisor AgentWorkshop.Workshop.Supervisor
 
-  @special_keys [:backend, :backend_config, :context, :workshop_tools, :max_cost_usd]
+  @special_keys [:backend, :backend_config, :context, :workshop_tools, :skill, :max_cost_usd]
   @max_queue_size 5
   @valid_permission_modes [:default, :accept_edits, :bypass_permissions, :dont_ask, :plan, :auto]
 
@@ -322,12 +322,16 @@ defmodule AgentWorkshop.Workshop do
             "no backend configured. Call configure(backend: MyModule) first."
     end
 
-    # Compose system prompt: global context + agent role
-    system_prompt = compose_system_prompt(global.context, role)
-
     # Extract special opts
     {workshop_tools, opts} = Keyword.pop(opts, :workshop_tools, false)
+    {skill, opts} = Keyword.pop(opts, :skill)
     {agent_max_cost, opts} = Keyword.pop(opts, :max_cost_usd)
+
+    # Compose system prompt: skill context + global context + role
+    skill_context =
+      AgentWorkshop.Skills.context_for(workshop_tools: workshop_tools, skill: skill)
+
+    system_prompt = compose_system_prompt(skill_context, global.context, role)
 
     # Merge global query opts with agent-specific opts (agent wins)
     agent_query_opts = split_opts(opts)
@@ -462,7 +466,15 @@ defmodule AgentWorkshop.Workshop do
     end
 
     global = get_global_state()
-    system_prompt = compose_system_prompt(global.context, entry.role)
+
+    # Reconstruct skill context for reset
+    workshop_tools = Keyword.get(entry.agent_opts, :workshop_tools, false)
+    skill = Keyword.get(entry.agent_opts, :skill)
+
+    skill_context =
+      AgentWorkshop.Skills.context_for(workshop_tools: workshop_tools, skill: skill)
+
+    system_prompt = compose_system_prompt(skill_context, global.context, entry.role)
 
     agent_query_opts = split_opts(entry.agent_opts)
     query_opts = Keyword.merge(global.query_opts, agent_query_opts)
@@ -1735,8 +1747,8 @@ defmodule AgentWorkshop.Workshop do
     end
   end
 
-  defp compose_system_prompt(context, role) do
-    [context, role]
+  defp compose_system_prompt(skill_context, user_context, role) do
+    [skill_context, user_context, role]
     |> Enum.reject(fn s -> is_nil(s) or String.trim(s) == "" end)
     |> case do
       [] -> nil

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule AgentWorkshop.MixProject do
     [
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url},
-      files: ~w(lib mix.exs README.md LICENSE .formatter.exs),
+      files: ~w(lib skills AGENTS.md mix.exs README.md LICENSE .formatter.exs),
       maintainers: ["Josh Rotenberg"]
     ]
   end

--- a/skills/board/SKILL.md
+++ b/skills/board/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: board
+description: Work board driven development. Post typed work items with dependencies, agents poll by role. Use for multi-step features where ordering matters.
+license: MIT
+metadata:
+  author: joshrotenberg
+  version: "1.0"
+---
+
+# Board
+
+Structured task tracker. Work items have types, dependencies, and lifecycle states. Agents claim work matching their role.
+
+## Setup
+
+```elixir
+agent(:coder, "Check the board for :code items. Claim one, implement it, mark done.",
+  work_types: [:code])
+agent(:reviewer, "Check the board for :review items. Claim one, review it.",
+  work_types: [:review])
+```
+
+## Usage
+
+```elixir
+# Post work
+work(:cache, "Implement LRU cache", type: :code, priority: 1,
+  spec: "LRU with TTL, max 1000 entries")
+work(:cache_review, "Review cache", type: :review, depends_on: [:cache])
+work(:cache_tests, "Test cache", type: :test, depends_on: [:cache])
+
+# Check board
+board()
+board(status: :ready)
+
+# Agents claim and advance
+claim_work(:cache, :coder)
+start_work(:cache)
+complete_work(:cache, "Done with GenServer-backed LRU")
+# :cache_review and :cache_tests auto-unblock to :ready
+```
+
+## When to use
+
+- Multi-step features with natural ordering
+- Multiple agents working on different aspects
+- You want visibility into what's done and what's pending
+- Work is organic — items can be added mid-flight
+
+## Board vs pipe
+
+**Pipe**: you control the flow manually. A then B then C.
+**Board**: agents self-organize. Dependencies handle ordering. New work can be added anytime.

--- a/skills/mixed/SKILL.md
+++ b/skills/mixed/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: mixed
+description: Multiple LLM backends in one workshop. Claude and Codex agents working together. Use when different models have different strengths.
+license: MIT
+metadata:
+  author: joshrotenberg
+  version: "1.0"
+---
+
+# Mixed Backends
+
+Different LLMs for different roles. Same Workshop API regardless of backend.
+
+## Setup
+
+```elixir
+configure(backend: AgentWorkshop.Backends.Claude,
+  backend_config: ClaudeWrapper.Config.new(working_dir: "."))
+
+agent(:impl, "You write code.", model: "sonnet")
+agent(:reviewer, "Review only.",
+  backend: AgentWorkshop.Backends.Codex,
+  backend_config: CodexWrapper.Config.new(working_dir: "."),
+  model: "o3")
+```
+
+## When to use
+
+- Different models excel at different tasks
+- You want multiple perspectives from different LLMs
+- Cost optimization (cheaper model for simple tasks)

--- a/skills/monitor/SKILL.md
+++ b/skills/monitor/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: monitor
+description: Scheduled agent for periodic checks. Use for CI monitoring, PR scanning, health checks, or any polling-based workflow.
+license: MIT
+metadata:
+  author: joshrotenberg
+  version: "1.0"
+---
+
+# Monitor
+
+A scheduled agent that runs a prompt on a recurring interval.
+
+## Setup
+
+```elixir
+agent(:monitor, "You check project health and report issues.")
+every(:monitor, "Check CI status. Report any failures.", interval: :timer.minutes(5))
+```
+
+## Usage
+
+```elixir
+schedules()          # list active schedules
+cancel(:monitor)     # stop
+```
+
+## When to use
+
+- CI status monitoring
+- Scanning for unreviewed PRs
+- Periodic health checks
+- Polling for external events

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: orchestrator
+description: Coordinate a team of AI agents to build software. Break tasks down, create specialist agents from profiles, delegate via ask/cast, review results, and clean up. Use when you need to orchestrate multi-agent workflows.
+license: MIT
+metadata:
+  author: joshrotenberg
+  version: "1.0"
+---
+
+# Orchestrator
+
+You are a team coordinator. You have Workshop MCP tools to create and manage agents. Your job is to plan, delegate, and verify — never to write code yourself.
+
+## Setup
+
+```elixir
+# .workshop.exs
+profile(:coder, "You write clean, well-tested code.", max_turns: 15)
+profile(:reviewer, "Review only. Do not modify files.",
+  model: "opus", allowed_tools: ["Read", "Bash"])
+
+agent(:orchestrator, "You coordinate agents.",
+  workshop_tools: true, model: "opus", max_turns: 30)
+```
+
+## Workflow
+
+### 1. Plan
+
+Break the task into discrete work units. Each unit should be completable by one agent in one session.
+
+### 2. Create agents
+
+Use `from_profile` to create specialist agents. Name them descriptively:
+
+```
+from_profile(profile: "coder", name: "coder-auth")
+from_profile(profile: "coder", name: "coder-tests")
+from_profile(profile: "reviewer", name: "reviewer")
+```
+
+### 3. Delegate
+
+**Sequential** (when order matters):
+```
+ask(agent: "coder-auth", prompt: "Implement the auth module...")
+```
+
+**Parallel** (independent tasks):
+```
+cast(agent: "coder-auth", prompt: "Implement auth module...")
+cast(agent: "coder-tests", prompt: "Write tests for...")
+await_all(timeout: 300000)
+```
+
+### 4. Review
+
+Always create a reviewer. Send implementation results for review:
+
+```
+ask(agent: "reviewer", prompt: "Review the changes in lib/...")
+```
+
+### 5. Fix
+
+If the reviewer finds issues, send feedback back to the coder:
+
+```
+ask(agent: "coder-auth", prompt: "Address these review findings: ...")
+```
+
+### 6. Clean up
+
+Dismiss agents when their work is done:
+
+```
+dismiss(agent: "coder-auth")
+dismiss(agent: "coder-tests")
+dismiss(agent: "reviewer")
+```
+
+## Rules
+
+- **Never write code yourself.** Always delegate to a coder agent.
+- **Never skip review.** Always create a reviewer agent.
+- **Name agents descriptively.** `:coder-status`, not `:agent1`.
+- **Use cast for parallel work.** Don't ask sequentially when tasks are independent.
+- **Run tests.** Tell coders to run tests before reporting completion.
+- **Report a summary** when all work is complete: what was built, test results, cost.
+
+## Common mistakes
+
+- Writing code directly instead of delegating (defeats the purpose of orchestration)
+- Asking agents sequentially when they could work in parallel
+- Not dismissing agents when done (wastes resources)
+- Giving vague instructions to coders (be specific about files, functions, test coverage)

--- a/skills/pair/SKILL.md
+++ b/skills/pair/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: pair
+description: Implement-then-review pattern. Two agents collaborating via pipe chains. Use when you need a second perspective on code changes.
+license: MIT
+metadata:
+  author: joshrotenberg
+  version: "1.0"
+---
+
+# Pair
+
+Two agents: one builds, one reviews. Connected via `pipe`.
+
+## Setup
+
+```elixir
+agent(:impl, "You write clean, well-tested code.", max_turns: 15)
+agent(:reviewer, "You review code. Do not modify files.",
+  model: "opus", allowed_tools: ["Read", "Bash"])
+```
+
+## Usage
+
+```elixir
+ask(:impl, "Implement the caching layer")
+|> pipe(:reviewer, "Review for edge cases")
+
+# If reviewer finds issues:
+ask(:impl, "Address this feedback: #{result(:reviewer)}")
+|> pipe(:reviewer, "Check if the issues are resolved")
+```
+
+## When to use
+
+- You have a clear task and want quality assurance
+- Changes are focused enough for one agent to implement
+- You want review feedback before moving on
+
+## Agent guidance
+
+**If you are the implementor**: Write code, include tests, run them before reporting. Be specific about what you changed and why.
+
+**If you are the reviewer**: Read the diff carefully. Report findings as a prioritized list. Do not modify files. Focus on correctness, edge cases, and style.

--- a/skills/solo/SKILL.md
+++ b/skills/solo/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: solo
+description: Single agent, direct interaction. The simplest Workshop setup. Use for quick tasks, exploration, or when one agent is enough.
+license: MIT
+metadata:
+  author: joshrotenberg
+  version: "1.0"
+---
+
+# Solo
+
+One agent, one conversation. Use `ask` for back-and-forth, `cast` for background work.
+
+## Setup
+
+```elixir
+configure(backend: AgentWorkshop.Backends.Claude,
+  backend_config: ClaudeWrapper.Config.new(working_dir: "."),
+  model: "sonnet", permission_mode: :bypass_permissions)
+
+agent(:dev, "You are a helpful software engineer.")
+```
+
+## Usage
+
+```elixir
+ask(:dev, "What's in this project?")
+ask(:dev, "Add tests for the retry module")
+cast(:dev, "Refactor the config module")
+status()
+await(:dev)
+```
+
+## When to use
+
+- Quick exploration or questions
+- Single-focus tasks
+- When coordination overhead isn't worth it


### PR DESCRIPTION
## Summary

Skills follow the [agentskills.io](https://agentskills.io) open standard. AGENTS.md provides top-level context. Both auto-inject into agent system prompts.

### Layered context (what the agent sees)

1. **AGENTS.md** — "you are a Workshop agent" (only for workshop_tools: true agents)
2. **Skill** — "your pattern is orchestrator/pair/etc." (when skill: :name is set)
3. **User context** — configure(context: "Elixir project...")
4. **Role** — agent(:impl, "You write clean code.")

### 6 skills

| Skill | Pattern |
|---|---|
| solo | Single agent, direct interaction |
| pair | Implement + review via pipe |
| board | Work board driven, agents poll by role |
| orchestrator | Coordinator with workshop_tools |
| monitor | Scheduled periodic checks |
| mixed | Multiple backends |

### AGENTS.md highlights

- Tells orchestrators: "You MUST delegate, do not write code yourself"
- Lists available tools with what to use them for
- Defines rules: always review, name agents descriptively, dismiss when done
- Separate guidance for coders and reviewers

This should fix the orchestrator "doing everything itself" problem from the demo.

Closes #22

## Test plan

- [x] 72 tests pass
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix credo --strict` clean
- [ ] Manual: run orchestrator demo, verify it reads AGENTS.md and delegates