### PR TITLE
feat: board workers — agents that poll and execute work items

### DIFF
--- a/lib/agent_workshop/board_worker.ex
+++ b/lib/agent_workshop/board_worker.ex
@@ -1,0 +1,208 @@
+defmodule AgentWorkshop.BoardWorker do
+  @moduledoc """
+  A board-aware agent that polls for work, claims it, executes, and reports.
+
+  Combines an agent (from a profile), a scheduler, and the work board
+  into a single first-class concept. The worker:
+
+  1. Polls the board for `:ready` items matching its work type
+  2. Claims the highest priority item
+  3. Sends the item's title + spec as a prompt to its agent
+  4. Marks the item complete (or failed) based on the result
+  5. Repeats
+
+  ## Usage
+
+      board_worker(:coder_1, :code, profile: :coder, interval: :timer.minutes(1))
+      board_worker(:reviewer_1, :review, profile: :reviewer, interval: :timer.minutes(2))
+
+      # Post work — workers pick it up automatically
+      work(:checkout, "Implement git checkout", type: :code, spec: "...")
+      work(:checkout_review, "Review checkout", type: :review, depends_on: [:checkout])
+  """
+
+  use GenServer
+
+  alias AgentWorkshop.{PubSub, Telemetry, Work, Workshop}
+
+  @registry AgentWorkshop.BoardWorker.Registry
+
+  defstruct [
+    :agent_name,
+    :work_type,
+    :interval,
+    :timer_ref,
+    claims_completed: 0,
+    current_item: nil
+  ]
+
+  # ── Client API ──────────────────────────────────────────────
+
+  @doc false
+  def start_link(opts) do
+    agent_name = Keyword.fetch!(opts, :agent_name)
+    GenServer.start_link(__MODULE__, opts, name: via(agent_name))
+  end
+
+  @doc false
+  def stop(agent_name) do
+    case Registry.lookup(@registry, agent_name) do
+      [{pid, _}] -> GenServer.stop(pid, :normal)
+      [] -> :ok
+    end
+  catch
+    :exit, _ -> :ok
+  end
+
+  @doc false
+  def get_info(agent_name) do
+    case Registry.lookup(@registry, agent_name) do
+      [{pid, _}] -> GenServer.call(pid, :info)
+      [] -> nil
+    end
+  catch
+    :exit, _ -> nil
+  end
+
+  @doc false
+  def list_all do
+    @registry
+    |> Registry.select([{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+    |> Enum.filter(fn {_name, pid} -> Process.alive?(pid) end)
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.sort()
+  end
+
+  @doc false
+  def start_registry do
+    case Registry.start_link(keys: :unique, name: @registry) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+  end
+
+  # ── GenServer callbacks ─────────────────────────────────────
+
+  @impl true
+  def init(opts) do
+    agent_name = Keyword.fetch!(opts, :agent_name)
+    work_type = Keyword.fetch!(opts, :work_type)
+    interval = Keyword.fetch!(opts, :interval)
+
+    state = %__MODULE__{
+      agent_name: agent_name,
+      work_type: work_type,
+      interval: interval
+    }
+
+    timer_ref = Process.send_after(self(), :poll, interval)
+    {:ok, %{state | timer_ref: timer_ref}}
+  end
+
+  @impl true
+  def handle_info(:poll, state) do
+    state = try_claim_and_execute(state)
+    timer_ref = Process.send_after(self(), :poll, state.interval)
+    {:noreply, %{state | timer_ref: timer_ref}}
+  end
+
+  @impl true
+  def handle_call(:info, _from, state) do
+    info = %{
+      agent_name: state.agent_name,
+      work_type: state.work_type,
+      interval: state.interval,
+      claims_completed: state.claims_completed,
+      current_item: state.current_item
+    }
+
+    {:reply, info, state}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    if state.timer_ref, do: Process.cancel_timer(state.timer_ref)
+    :ok
+  end
+
+  # ── Internal ────────────────────────────────────────────────
+
+  defp try_claim_and_execute(state) do
+    # Check if agent is busy
+    case Workshop.info(state.agent_name) do
+      %{status: :working} ->
+        state
+
+      _ ->
+        claim_next(state)
+    end
+  rescue
+    _ -> state
+  end
+
+  defp claim_next(state) do
+    ready_items = Work.list(status: :ready, type: state.work_type)
+
+    case ready_items do
+      [] ->
+        state
+
+      [item | _] ->
+        case Work.claim(item.id, state.agent_name) do
+          :ok ->
+            execute_item(item, state)
+
+          {:error, _} ->
+            state
+        end
+    end
+  end
+
+  defp execute_item(item, state) do
+    Work.start_work(item.id)
+    Telemetry.event(:board_worker_started, %{}, %{agent: state.agent_name, item: item.id})
+    PubSub.broadcast({:board_worker, :started, state.agent_name, item.id})
+
+    prompt = build_prompt(item)
+
+    # Use cast so we don't block the poll loop
+    Workshop.cast(state.agent_name, prompt)
+
+    # Spawn a watcher that waits for the agent to finish and marks the item
+    spawn(fn -> watch_completion(state.agent_name, item.id) end)
+
+    %{state | current_item: item.id}
+  end
+
+  defp watch_completion(agent_name, item_id) do
+    Process.sleep(2_000)
+
+    case Workshop.info(agent_name) do
+      %{status: :idle} ->
+        result_text = Workshop.result(agent_name)
+        Work.complete(item_id, result_text)
+        Telemetry.event(:board_worker_completed, %{}, %{agent: agent_name, item: item_id})
+        PubSub.broadcast({:board_worker, :completed, agent_name, item_id})
+
+      %{status: :working} ->
+        watch_completion(agent_name, item_id)
+
+      _ ->
+        Work.fail(item_id, "agent unavailable")
+    end
+  rescue
+    _ -> Work.fail(item_id, "watcher crashed")
+  end
+
+  defp build_prompt(item) do
+    if item.spec do
+      "#{item.title}\n\nSpec:\n#{item.spec}"
+    else
+      item.title
+    end
+  end
+
+  defp via(agent_name) do
+    {:via, Registry, {@registry, agent_name}}
+  end
+end

--- a/lib/agent_workshop/workshop.ex
+++ b/lib/agent_workshop/workshop.ex
@@ -116,6 +116,7 @@ defmodule AgentWorkshop.Workshop do
     # Start registries (before supervisor, so they're available immediately)
     AgentWorkshop.PubSub.start_registry()
     AgentWorkshop.Scheduler.start_registry()
+    AgentWorkshop.BoardWorker.start_registry()
 
     # Agent init creates ETS tables so they're owned by a supervised process
     agent_init = fn ->
@@ -1067,6 +1068,72 @@ defmodule AgentWorkshop.Workshop do
     Work.get(id)
   end
 
+  # ── Board Workers ────────────────────────────────────────────
+
+  @doc """
+  Create a board worker — an agent that polls the board for work.
+
+  Combines a profile, an agent, and a poll loop. The worker claims
+  ready items matching its work type, executes them, and marks them
+  complete.
+
+  ## Options
+
+    * `:profile` - (required) profile name to create the agent from
+    * `:interval` - poll interval in ms (default: 60_000 / 1 min)
+
+  ## Examples
+
+      board_worker(:coder_1, :code, profile: :coder, interval: :timer.minutes(1))
+      board_worker(:reviewer_1, :review, profile: :reviewer, interval: :timer.minutes(2))
+
+      # Post work — workers pick it up automatically
+      work(:feature, "Implement feature X", type: :code, spec: "...")
+  """
+  @spec board_worker(atom(), atom(), keyword()) :: :ok
+  def board_worker(name, work_type, opts \\ []) do
+    ensure_started()
+
+    profile_name = Keyword.fetch!(opts, :profile)
+    interval = Keyword.get(opts, :interval, 60_000)
+
+    # Create the agent from profile
+    from_profile(profile_name, name, Keyword.drop(opts, [:profile, :interval]))
+
+    # Start the board worker loop
+    {:ok, _pid} =
+      DynamicSupervisor.start_child(@sessions_sup, {
+        AgentWorkshop.BoardWorker,
+        agent_name: name, work_type: work_type, interval: interval
+      })
+
+    print_info(
+      "#{inspect(name)}: board worker for #{inspect(work_type)} (every #{format_interval(interval)})"
+    )
+
+    :ok
+  end
+
+  @doc """
+  List active board workers.
+  """
+  @spec workers() :: :ok
+  def workers do
+    ensure_started()
+    names = AgentWorkshop.BoardWorker.list_all()
+
+    if names == [] do
+      print_info("No board workers.")
+    else
+      names
+      |> Enum.map(&AgentWorkshop.BoardWorker.get_info/1)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.each(&print_worker_info/1)
+    end
+
+    :ok
+  end
+
   # ── Interaction ───────────────────────────────────────────────
 
   @doc """
@@ -1844,6 +1911,14 @@ defmodule AgentWorkshop.Workshop do
       "  #{status_color}[#{item.status}]#{IO.ANSI.reset()} " <>
         "#{inspect(item.id)} - #{item.title}" <>
         " [#{item.type}]#{claimed}#{deps}"
+    )
+  end
+
+  defp print_worker_info(info) do
+    current = if info.current_item, do: " (working on #{inspect(info.current_item)})", else: ""
+
+    print_info(
+      "#{inspect(info.agent_name)}: #{info.work_type}, #{info.claims_completed} completed#{current}"
     )
   end
 


### PR DESCRIPTION
## Summary

First-class agents that combine profiles, the work board, and a poll loop.

```elixir
profile(:coder, "You write clean code.", max_turns: 15)
profile(:reviewer, "Review only.", model: "opus")

board_worker(:coder_1, :code, profile: :coder, interval: :timer.minutes(1))
board_worker(:reviewer_1, :review, profile: :reviewer)

# Post work — workers pick it up
work(:feature, "Implement checkout command", type: :code,
  spec: "Follow existing patterns in lib/git_wrapper/commands/")
work(:feature_review, "Review checkout", type: :review, depends_on: [:feature])
```

Workers poll → claim → execute → mark done → repeat. Dependencies auto-unblock.

## Test plan

- [x] 72 tests pass
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix credo --strict` clean
- [ ] Manual: post work items, verify workers claim and execute