### PR TITLE
feat: worktree support for board workers

### DIFF
--- a/lib/agent_workshop/board_worker.ex
+++ b/lib/agent_workshop/board_worker.ex
@@ -32,6 +32,7 @@ defmodule AgentWorkshop.BoardWorker do
     :work_type,
     :interval,
     :timer_ref,
+    worktree: false,
     claims_completed: 0,
     current_item: nil
   ]
@@ -88,11 +89,13 @@ defmodule AgentWorkshop.BoardWorker do
     agent_name = Keyword.fetch!(opts, :agent_name)
     work_type = Keyword.fetch!(opts, :work_type)
     interval = Keyword.fetch!(opts, :interval)
+    worktree = Keyword.get(opts, :worktree, false)
 
     state = %__MODULE__{
       agent_name: agent_name,
       work_type: work_type,
-      interval: interval
+      interval: interval,
+      worktree: worktree
     }
 
     timer_ref = Process.send_after(self(), :poll, interval)
@@ -123,6 +126,7 @@ defmodule AgentWorkshop.BoardWorker do
       agent_name: state.agent_name,
       work_type: state.work_type,
       interval: state.interval,
+      worktree: state.worktree,
       claims_completed: state.claims_completed,
       current_item: state.current_item
     }

--- a/lib/agent_workshop/workshop.ex
+++ b/lib/agent_workshop/workshop.ex
@@ -1081,6 +1081,8 @@ defmodule AgentWorkshop.Workshop do
 
     * `:profile` - (required) profile name to create the agent from
     * `:interval` - poll interval in ms (default: 60_000 / 1 min)
+    * `:worktree` - when `true`, passes `worktree: true` to the agent's query opts,
+      enabling the Claude CLI `--worktree` flag for isolated parallel execution
 
   ## Examples
 
@@ -1096,15 +1098,16 @@ defmodule AgentWorkshop.Workshop do
 
     profile_name = Keyword.fetch!(opts, :profile)
     interval = Keyword.get(opts, :interval, 60_000)
+    worktree = Keyword.get(opts, :worktree, false)
 
-    # Create the agent from profile
+    # Create the agent from profile, threading worktree into query_opts
     from_profile(profile_name, name, Keyword.drop(opts, [:profile, :interval]))
 
     # Start the board worker loop
     {:ok, _pid} =
       DynamicSupervisor.start_child(@sessions_sup, {
         AgentWorkshop.BoardWorker,
-        agent_name: name, work_type: work_type, interval: interval
+        agent_name: name, work_type: work_type, interval: interval, worktree: worktree
       })
 
     print_info(


### PR DESCRIPTION
board_worker/3 accepts worktree: true for isolated parallel execution.

```elixir
board_worker(:coder_1, :code, profile: :coder, worktree: true)
board_worker(:coder_2, :code, profile: :coder, worktree: true)
# Each coder gets its own git worktree — no conflicts
```

Requires claude_wrapper_ex PR #39 (worktree in Session.build_query).

Built by Workshop agent :fixer ($0.41). Dogfooding.

Closes #41