### PR TITLE
feat: agent timeout + diagnostic logging for CLI hangs

### DIFF
--- a/lib/agent_workshop/workshop.ex
+++ b/lib/agent_workshop/workshop.ex
@@ -1,5 +1,6 @@
 defmodule AgentWorkshop.Workshop do
   require Logger
+
   @moduledoc """
   Multi-agent IEx API for coordinating LLM CLI sessions.
 
@@ -83,7 +84,15 @@ defmodule AgentWorkshop.Workshop do
   @tasks_sup AgentWorkshop.Workshop.TasksSupervisor
   @supervisor AgentWorkshop.Workshop.Supervisor
 
-  @special_keys [:backend, :backend_config, :context, :workshop_tools, :skill, :max_cost_usd, :timeout]
+  @special_keys [
+    :backend,
+    :backend_config,
+    :context,
+    :workshop_tools,
+    :skill,
+    :max_cost_usd,
+    :timeout
+  ]
   @max_queue_size 5
   @valid_permission_modes [:default, :accept_edits, :bypass_permissions, :dont_ask, :plan, :auto]
 


### PR DESCRIPTION
Agent timeout and logging for diagnosing stuck CLI processes.

```elixir
agent(:impl, "Coder", timeout: :timer.minutes(5))
# If CLI doesn't return in 5 min, agent goes back to idle
```

Also adds Logger.info before/after send_message calls.

Built by Workshop agent :fixer ($0.48). Dogfooding.

Closes #43