### PR TITLE
Fix scheduler test race condition

### DIFF
--- a/test/agent_workshop_test.exs
+++ b/test/agent_workshop_test.exs
@@ -523,10 +523,10 @@ defmodule AgentWorkshop.WorkshopTest do
 
     test "schedules/0 works" do
       setup_mock()
-      Workshop.agent(:monitor, "Monitor")
-      Workshop.every(:monitor, "check", interval: 60_000)
+      Workshop.agent(:poller, "Poller")
+      Workshop.every(:poller, "check", interval: 60_000)
       assert is_list(Workshop.schedules())
-      Workshop.cancel(:monitor)
+      Workshop.cancel(:poller)
     end
   end
 


### PR DESCRIPTION
## Summary

The `schedules/0 works` test intermittently fails with `{:error, {:already_started, ...}}` because the preceding `cancel stops the schedule` test's `:monitor` scheduler hasn't fully cleaned up from the DynamicSupervisor before the next test reuses the same name.

Fix: use a unique name (`:poller`) to avoid the race.

## Test plan

- [ ] `mix test --seed 612065` -- reproduces the failure before, passes after
- [ ] `mix test` -- 90 tests, 0 failures