### PR TITLE
feat: GitHub integration skill and example config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: "1.18"
-            otp: "27"
+          - elixir: "1.19"
+            otp: "28"
 
     steps:
       - uses: actions/checkout@v6
@@ -66,8 +66,8 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          elixir-version: "1.18"
-          otp-version: "27"
+          elixir-version: "1.19"
+          otp-version: "28"
 
       - name: Restore deps cache
         uses: actions/cache@v5
@@ -75,7 +75,7 @@ jobs:
           path: |
             deps
             _build
-          key: mix-docs-1.18-27-${{ hashFiles('mix.lock') }}
+          key: mix-docs-1.19-28-${{ hashFiles('mix.lock') }}
 
       - name: Install dependencies
         run: mix deps.get

--- a/examples/github_sync.exs
+++ b/examples/github_sync.exs
@@ -10,7 +10,8 @@ configure(
   mcp: [port: 4222]
 )
 
-agent(:github_sync,
+agent(
+  :github_sync,
   "You are a GitHub sync agent. You bridge GitHub issues and the Workshop board.",
   workshop_tools: true,
   skill: :github,
@@ -18,18 +19,20 @@ agent(:github_sync,
   max_turns: 15
 )
 
-every(:github_sync, """
-Sync GitHub issues to the board.
+every(
+  :github_sync,
+  """
+  Sync GitHub issues to the board.
 
-1. Run: gh issue list --label "agent" --state open --json number,title,body,labels
-2. Run: board() to see existing items
-3. For each issue not already on the board (match by id "gh_<number>"):
-   - add_work(id: "gh_<number>", title: "<issue title>", type: "triage", priority: 3, spec: "<issue body>")
-   - Comment on the issue: gh issue comment <number> --body "Synced to board as gh_<number>"
-4. Report what you synced (or "nothing new" if no new issues)
+  1. Run: gh issue list --label "agent" --state open --json number,title,body,labels
+  2. Run: board() to see existing items
+  3. For each issue not already on the board (match by id "gh_<number>"):
+     - add_work(id: "gh_<number>", title: "<issue title>", type: "triage", priority: 3, spec: "<issue body>")
+     - Comment on the issue: gh issue comment <number> --body "Synced to board as gh_<number>"
+  4. Report what you synced (or "nothing new" if no new issues)
 
-Do NOT re-add issues already on the board in any status.
-""", interval: :timer.minutes(5))
+  Do NOT re-add issues already on the board in any status.
+  """, interval: :timer.minutes(5))
 
 # Optional: board workers to process synced issues.
 # Uncomment to enable automatic processing.

--- a/examples/github_sync.exs
+++ b/examples/github_sync.exs
@@ -32,7 +32,9 @@ every(
   4. Report what you synced (or "nothing new" if no new issues)
 
   Do NOT re-add issues already on the board in any status.
-  """, interval: :timer.minutes(5))
+  """,
+  interval: :timer.minutes(5)
+)
 
 # Optional: board workers to process synced issues.
 # Uncomment to enable automatic processing.

--- a/examples/github_sync.exs
+++ b/examples/github_sync.exs
@@ -1,0 +1,50 @@
+# GitHub Sync -- poll issues, create board items, create PRs for completed work.
+# Requires: gh CLI authenticated (run `gh auth status` to verify).
+
+configure(
+  backend: AgentWorkshop.Backends.Claude,
+  backend_config: ClaudeWrapper.Config.new(working_dir: "."),
+  model: "sonnet",
+  permission_mode: :bypass_permissions,
+  context: "You sync GitHub issues to the Workshop board and create PRs for completed work.",
+  mcp: [port: 4222]
+)
+
+agent(:github_sync,
+  "You are a GitHub sync agent. You bridge GitHub issues and the Workshop board.",
+  workshop_tools: true,
+  skill: :github,
+  model: "sonnet",
+  max_turns: 15
+)
+
+every(:github_sync, """
+Sync GitHub issues to the board.
+
+1. Run: gh issue list --label "agent" --state open --json number,title,body,labels
+2. Run: board() to see existing items
+3. For each issue not already on the board (match by id "gh_<number>"):
+   - add_work(id: "gh_<number>", title: "<issue title>", type: "triage", priority: 3, spec: "<issue body>")
+   - Comment on the issue: gh issue comment <number> --body "Synced to board as gh_<number>"
+4. Report what you synced (or "nothing new" if no new issues)
+
+Do NOT re-add issues already on the board in any status.
+""", interval: :timer.minutes(5))
+
+# Optional: board workers to process synced issues.
+# Uncomment to enable automatic processing.
+#
+# profile(:coder, "You write clean, well-tested code.", max_turns: 15)
+#
+# board_worker(:dev_1, :code, profile: :coder,
+#   interval: :timer.seconds(30), worktree: true)
+#
+# When a board worker completes an item, it can create a PR:
+#   gh pr create --title "fix: <title>" --body "Closes #<number>"
+# The github skill teaches agents how to do this.
+
+# Usage:
+#   schedules()          # see sync schedule
+#   cast(:github_sync, "Sync now.")  # manual trigger
+#   board()              # see synced items
+#   workers()            # see worker status (if enabled)

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: github
+description: GitHub integration via gh CLI. List issues, create PRs, comment on issues. Use for agents that bridge GitHub and the Workshop board.
+license: MIT
+metadata:
+  author: joshrotenberg
+  version: "1.0"
+---
+
+# GitHub
+
+Bridge GitHub issues and PRs with the Workshop board using the `gh` CLI.
+
+## Prerequisites
+
+Verify authentication before any operation:
+
+```bash
+gh auth status
+```
+
+## Reading issues
+
+```bash
+# List open issues with a label
+gh issue list --label "agent" --state open --json number,title,body,labels --limit 50
+
+# Read a single issue
+gh issue view 42 --json number,title,body,labels,comments
+```
+
+Always use `--json` for structured output.
+
+## Board integration
+
+When syncing issues to the board, use the ID convention `gh_<number>` for dedup:
+
+```elixir
+# Check if already on the board before adding
+board()
+
+# Add a new work item from an issue
+add_work(id: "gh_42", title: "Issue title", type: "triage", priority: 3,
+  spec: "Issue body text here")
+```
+
+Skip issues that already have a board item (any status).
+
+## Creating PRs
+
+After work is completed on a branch:
+
+```bash
+# Create PR linking back to the issue
+gh pr create --title "fix: description" --body "Closes #42" --head branch-name --base main
+```
+
+Use `Closes #N` in the PR body to auto-close the issue on merge.
+
+## Commenting and labeling
+
+```bash
+# Status update on an issue
+gh issue comment 42 --body "Picked up by agent, work item gh_42 created."
+
+# Label management
+gh issue edit 42 --add-label "in-progress"
+gh issue edit 42 --remove-label "agent"
+```
+
+## When to use
+
+- Sync GitHub issues to the board for agent processing
+- Create PRs from completed board work
+- Keep issue status in sync with board state


### PR DESCRIPTION
## Summary
- Add `skills/github/SKILL.md` teaching agents `gh` CLI operations (list issues, create PRs, comment, label) and the board dedup convention (`gh_<number>` IDs)
- Add `examples/github_sync.exs` with a scheduled sync agent that polls issues and creates board items
- Zero library code changes -- layers 1-2 of #66

Closes #66

## Test plan
- [x] Skill discovered by `AgentWorkshop.Skills.list/0`
- [x] Compiles clean with `--warnings-as-errors`
- [ ] Manual test: load config, verify sync agent polls and creates board items