### PR TITLE
feat: declarative workflows -- staged pipelines with result flow

### DIFF
--- a/examples/workflow.exs
+++ b/examples/workflow.exs
@@ -1,0 +1,58 @@
+# Workflow -- declarative multi-stage pipeline.
+# Stages run in dependency order. Results flow automatically.
+
+configure(
+  backend: AgentWorkshop.Backends.Claude,
+  backend_config: ClaudeWrapper.Config.new(working_dir: "."),
+  model: "sonnet",
+  permission_mode: :bypass_permissions,
+  context: "Software project. Follow existing patterns."
+)
+
+# Profiles for each role
+profile(:planner, "You break features into concrete implementation tasks.",
+  model: "sonnet",
+  max_turns: 5
+)
+
+profile(:coder, "You write clean, well-tested code.",
+  max_turns: 15,
+  timeout: :timer.minutes(5)
+)
+
+profile(:tester, "You write thorough tests. Run them and fix failures.",
+  max_turns: 10,
+  timeout: :timer.minutes(3)
+)
+
+profile(:reviewer, "Review for correctness, edge cases, and style. Do not modify files.",
+  model: "opus",
+  allowed_tools: ["Read", "Bash"]
+)
+
+# Define the pipeline
+workflow(:feature, [
+  {:plan, :planner, "Break this feature into implementation tasks"},
+  {:implement, :coder, "Implement the plan", from: :plan, type: :code},
+  {:test, :tester, "Write tests for the implementation", from: :implement, type: :test},
+  {:review, :reviewer, "Review implementation and tests",
+   from: [:implement, :test], type: :review}
+])
+
+# Board workers to execute stages
+board_worker(:dev_1, :code, profile: :coder, interval: :timer.seconds(30), worktree: true)
+board_worker(:dev_2, :test, profile: :tester, interval: :timer.seconds(30), worktree: true)
+board_worker(:rev_1, :review, profile: :reviewer, interval: :timer.seconds(30))
+
+# Usage:
+#   # Start the pipeline (first stage has no deps, runs immediately)
+#   run_workflow(:feature)
+#
+#   # Watch progress
+#   workflow_status(:feature)
+#   board()
+#   watch()
+#
+#   # Re-run after changes
+#   reset_workflow(:feature)
+#   run_workflow(:feature)

--- a/lib/agent_workshop/board_worker.ex
+++ b/lib/agent_workshop/board_worker.ex
@@ -265,7 +265,7 @@ defmodule AgentWorkshop.BoardWorker do
         item.title
       end
 
-    case Map.get(item.metadata || %{}, :from_stages, []) do
+    case Map.get(item.metadata, :from_stages, []) do
       [] -> base
       stage_ids -> append_stage_results(base, stage_ids)
     end

--- a/lib/agent_workshop/board_worker.ex
+++ b/lib/agent_workshop/board_worker.ex
@@ -23,7 +23,7 @@ defmodule AgentWorkshop.BoardWorker do
 
   use GenServer
 
-  alias AgentWorkshop.{PubSub, Telemetry, Work, Workshop}
+  alias AgentWorkshop.{PubSub, Telemetry, Work, Workflow, Workshop}
 
   @registry AgentWorkshop.BoardWorker.Registry
 
@@ -231,6 +231,13 @@ defmodule AgentWorkshop.BoardWorker do
         Work.complete(item_id, result_text)
         Telemetry.event(:board_worker_completed, %{}, %{agent: agent_name, item: item_id})
         PubSub.broadcast({:board_worker, :completed, agent_name, item_id})
+
+        # Check if this completion finishes a workflow
+        case Workflow.workflow_for_item(item_id) do
+          nil -> :ok
+          wf_name -> Workflow.check_completion(wf_name)
+        end
+
         # Reset agent session so it starts fresh for the next work item
         Workshop.reset(agent_name)
         send(worker_pid, {:work_done, item_id})
@@ -240,19 +247,46 @@ defmodule AgentWorkshop.BoardWorker do
 
       _ ->
         Work.fail(item_id, "agent unavailable")
+        check_workflow_failure(item_id)
         send(worker_pid, {:work_failed, item_id})
     end
   rescue
     _ ->
       Work.fail(item_id, "watcher crashed")
+      check_workflow_failure(item_id)
       send(worker_pid, {:work_failed, item_id})
   end
 
   defp build_prompt(item) do
-    if item.spec do
-      "#{item.title}\n\nSpec:\n#{item.spec}"
-    else
-      item.title
+    base =
+      if item.spec do
+        "#{item.title}\n\nSpec:\n#{item.spec}"
+      else
+        item.title
+      end
+
+    case Map.get(item.metadata || %{}, :from_stages, []) do
+      [] -> base
+      stage_ids -> append_stage_results(base, stage_ids)
+    end
+  end
+
+  defp append_stage_results(base, stage_ids) do
+    context =
+      Enum.map_join(stage_ids, "\n\n---\n\n", fn id ->
+        case Work.get(id) do
+          %{result: result} when is_binary(result) -> "## Result from #{id}\n\n#{result}"
+          _ -> ""
+        end
+      end)
+
+    "#{base}\n\n## Previous stage results\n\n#{context}"
+  end
+
+  defp check_workflow_failure(item_id) do
+    case Workflow.workflow_for_item(item_id) do
+      nil -> :ok
+      wf_name -> Workflow.check_completion(wf_name)
     end
   end
 

--- a/lib/agent_workshop/persistence.ex
+++ b/lib/agent_workshop/persistence.ex
@@ -21,7 +21,7 @@ defmodule AgentWorkshop.Persistence do
 
   use GenServer
 
-  alias AgentWorkshop.{PubSub, Store, Work}
+  alias AgentWorkshop.{PubSub, Store, Work, Workflow}
 
   @name __MODULE__
   @default_dir ".agent_workshop"
@@ -164,12 +164,14 @@ defmodule AgentWorkshop.Persistence do
   defp write_target({:work, _, _, _}), do: :work
   defp write_target({:store, _, _}), do: :store
   defp write_target({:store, _}), do: :store
+  defp write_target({:workflow, _, _}), do: :workflows
   defp write_target(_), do: nil
 
   defp flush_pending(state) do
     if state.enabled and state.dir do
       if :work in state.pending, do: write_work(state.dir)
       if :store in state.pending, do: write_store(state.dir)
+      if :workflows in state.pending, do: write_workflows(state.dir)
     end
 
     if state.timer do
@@ -185,6 +187,12 @@ defmodule AgentWorkshop.Persistence do
     items = Work.list() |> Enum.map(&Work.to_map/1)
     json = Jason.encode!(items, pretty: true)
     File.write!(Path.join(dir, "work.json"), json)
+  end
+
+  defp write_workflows(dir) do
+    workflows = Workflow.list() |> Enum.map(&Workflow.to_map/1)
+    json = Jason.encode!(workflows, pretty: true)
+    File.write!(Path.join(dir, "workflows.json"), json)
   end
 
   defp write_store(dir) do
@@ -231,6 +239,7 @@ defmodule AgentWorkshop.Persistence do
   defp load_from_disk(state) do
     load_work(state.dir)
     load_store(state.dir)
+    load_workflows(state.dir)
     state
   end
 
@@ -242,6 +251,20 @@ defmodule AgentWorkshop.Persistence do
       for map <- items do
         item = Work.from_map(map)
         :ets.insert(Work.table_name(), {item.id, item})
+      end
+    else
+      _ -> :ok
+    end
+  end
+
+  defp load_workflows(dir) do
+    path = Path.join(dir, "workflows.json")
+
+    with {:ok, contents} <- read_json_file(path),
+         {:ok, workflows} when is_list(workflows) <- Jason.decode(contents) do
+      for map <- workflows do
+        workflow = Workflow.from_map(map)
+        :ets.insert(Workflow.table_name(), {workflow.name, workflow})
       end
     else
       _ -> :ok

--- a/lib/agent_workshop/table_manager.ex
+++ b/lib/agent_workshop/table_manager.ex
@@ -19,7 +19,8 @@ defmodule AgentWorkshop.TableManager do
     :agent_workshop_store,
     :agent_workshop_work,
     :agent_workshop_budgets,
-    :agent_workshop_profiles
+    :agent_workshop_profiles,
+    :agent_workshop_workflows
   ]
 
   def start_link(_opts) do

--- a/lib/agent_workshop/work.ex
+++ b/lib/agent_workshop/work.ex
@@ -80,7 +80,8 @@ defmodule AgentWorkshop.Work do
     :completed_at,
     status: :new,
     priority: 3,
-    depends_on: []
+    depends_on: [],
+    metadata: %{}
   ]
 
   @type t :: %__MODULE__{
@@ -97,7 +98,8 @@ defmodule AgentWorkshop.Work do
           created_at: DateTime.t(),
           claimed_at: DateTime.t() | nil,
           started_at: DateTime.t() | nil,
-          completed_at: DateTime.t() | nil
+          completed_at: DateTime.t() | nil,
+          metadata: map()
         }
 
   # ── Table management ────────────────────────────────────────
@@ -130,6 +132,7 @@ defmodule AgentWorkshop.Work do
     spec = Keyword.get(opts, :spec)
     priority = Keyword.get(opts, :priority, 3)
     depends_on = Keyword.get(opts, :depends_on, [])
+    metadata = Keyword.get(opts, :metadata, %{})
 
     item = %__MODULE__{
       id: id,
@@ -138,6 +141,7 @@ defmodule AgentWorkshop.Work do
       type: type,
       priority: priority,
       depends_on: depends_on,
+      metadata: metadata,
       created_at: DateTime.utc_now()
     }
 
@@ -339,6 +343,7 @@ defmodule AgentWorkshop.Work do
       "claimed_by" => if(item.claimed_by, do: Atom.to_string(item.claimed_by)),
       "result" => item.result,
       "error" => item.error,
+      "metadata" => serialize_metadata(item.metadata),
       "created_at" => if(item.created_at, do: DateTime.to_iso8601(item.created_at)),
       "claimed_at" => if(item.claimed_at, do: DateTime.to_iso8601(item.claimed_at)),
       "started_at" => if(item.started_at, do: DateTime.to_iso8601(item.started_at)),
@@ -360,6 +365,7 @@ defmodule AgentWorkshop.Work do
       claimed_by: if(map["claimed_by"], do: String.to_atom(map["claimed_by"])),
       result: map["result"],
       error: map["error"],
+      metadata: deserialize_metadata(map["metadata"]),
       created_at: parse_datetime(map["created_at"]),
       claimed_at: parse_datetime(map["claimed_at"]),
       started_at: parse_datetime(map["started_at"]),
@@ -438,4 +444,27 @@ defmodule AgentWorkshop.Work do
   end
 
   defp apply_filters(items, [_ | rest]), do: apply_filters(items, rest)
+
+  defp serialize_metadata(nil), do: %{}
+
+  defp serialize_metadata(meta) when is_map(meta) do
+    Map.new(meta, fn
+      {k, v} when is_atom(k) -> {Atom.to_string(k), serialize_meta_value(v)}
+      {k, v} -> {k, serialize_meta_value(v)}
+    end)
+  end
+
+  defp serialize_meta_value(v) when is_atom(v), do: Atom.to_string(v)
+  defp serialize_meta_value(v) when is_list(v), do: Enum.map(v, &serialize_meta_value/1)
+  defp serialize_meta_value(v), do: v
+
+  defp deserialize_metadata(nil), do: %{}
+
+  defp deserialize_metadata(meta) when is_map(meta) do
+    Map.new(meta, fn {k, v} -> {String.to_atom(k), deserialize_meta_value(v)} end)
+  end
+
+  defp deserialize_meta_value(v) when is_binary(v), do: String.to_atom(v)
+  defp deserialize_meta_value(v) when is_list(v), do: Enum.map(v, &deserialize_meta_value/1)
+  defp deserialize_meta_value(v), do: v
 end

--- a/lib/agent_workshop/workflow.ex
+++ b/lib/agent_workshop/workflow.ex
@@ -1,0 +1,366 @@
+defmodule AgentWorkshop.Workflow do
+  @moduledoc """
+  Declarative workflows -- staged pipelines with file inputs.
+
+  A workflow defines a sequence of stages, each assigned to an agent or profile.
+  Stages can depend on previous stages (result piping) or read from files.
+  Under the hood, workflows expand into work board items with dependencies,
+  so board workers execute them automatically.
+
+  ## Defining a workflow
+
+      workflow(:feature, [
+        {:plan, :planner, "Break this into tasks", from: "specs/feature.md"},
+        {:implement, :coder, "Implement the plan", from: :plan},
+        {:test, :tester, "Write tests", from: :implement},
+        {:review, :reviewer, "Review everything", from: [:implement, :test]}
+      ])
+
+  ## Running
+
+      run_workflow(:feature)       # expands stages into work items
+      workflow_status(:feature)    # check progress
+      reset_workflow(:feature)     # clear and re-run
+
+  ## Stage options
+
+  - `from: "path/to/file.md"` -- read file content into spec
+  - `from: :stage_name` -- pipe previous stage's result
+  - `from: [:a, :b]` -- fan-in from multiple stages
+  - `type: :code` -- work board type (default: :custom)
+  - `priority: 1` -- priority (default: 3)
+  """
+
+  alias AgentWorkshop.{PubSub, Work}
+
+  @table :agent_workshop_workflows
+
+  defstruct [:name, :stages, :created_at, status: :defined]
+
+  @type stage :: %{
+          name: atom(),
+          work_id: atom(),
+          agent: atom(),
+          title: String.t(),
+          type: atom(),
+          priority: non_neg_integer(),
+          depends_on: [atom()],
+          from_stages: [atom()],
+          file_input: String.t() | nil
+        }
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          stages: [stage()],
+          created_at: DateTime.t(),
+          status: :defined | :running | :completed | :failed
+        }
+
+  # ── Table management ────────────────────────────────────────
+
+  @doc false
+  def table_name, do: @table
+
+  @doc false
+  def create_table do
+    if :ets.info(@table) == :undefined do
+      :ets.new(@table, [:named_table, :public, :set])
+    end
+  end
+
+  @doc false
+  def delete_table do
+    if :ets.info(@table) != :undefined do
+      :ets.delete(@table)
+    end
+  end
+
+  # ── Public API ─────────────────────────────────────────────
+
+  @doc """
+  Define a workflow. Validates and stores the stage definitions.
+  """
+  @spec define(atom(), list()) :: :ok | {:error, term()}
+  def define(name, stages) when is_atom(name) and is_list(stages) do
+    case parse_stages(name, stages) do
+      {:ok, parsed} ->
+        workflow = %__MODULE__{
+          name: name,
+          stages: parsed,
+          created_at: DateTime.utc_now()
+        }
+
+        :ets.insert(@table, {name, workflow})
+        PubSub.broadcast({:workflow, :defined, name})
+        :ok
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Run a workflow by expanding its stages into work board items.
+  """
+  @spec run(atom()) :: :ok | {:error, term()}
+  def run(name) do
+    case get(name) do
+      nil ->
+        {:error, :not_found}
+
+      %{status: :running} ->
+        {:error, :already_running}
+
+      workflow ->
+        expand_stages(workflow)
+        update_status(name, :running)
+        PubSub.broadcast({:workflow, :started, name})
+        :ok
+    end
+  end
+
+  @doc """
+  Reset a workflow -- removes all its work items and sets status back to :defined.
+  """
+  @spec reset(atom()) :: :ok | {:error, term()}
+  def reset(name) do
+    case get(name) do
+      nil ->
+        {:error, :not_found}
+
+      workflow ->
+        for stage <- workflow.stages do
+          Work.remove(stage.work_id)
+        end
+
+        update_status(name, :defined)
+        PubSub.broadcast({:workflow, :reset, name})
+        :ok
+    end
+  end
+
+  @doc """
+  Get a workflow definition.
+  """
+  @spec get(atom()) :: t() | nil
+  def get(name) do
+    case :ets.lookup(@table, name) do
+      [{^name, workflow}] -> workflow
+      [] -> nil
+    end
+  end
+
+  @doc """
+  Get workflow status with all stage items.
+  """
+  @spec status(atom()) :: {t(), [Work.t() | nil]} | {:error, :not_found}
+  def status(name) do
+    case get(name) do
+      nil ->
+        {:error, :not_found}
+
+      workflow ->
+        items = Enum.map(workflow.stages, fn s -> Work.get(s.work_id) end)
+        {workflow, items}
+    end
+  end
+
+  @doc """
+  List all defined workflows.
+  """
+  @spec list() :: [t()]
+  def list do
+    :ets.tab2list(@table)
+    |> Enum.map(&elem(&1, 1))
+    |> Enum.sort_by(& &1.name)
+  end
+
+  @doc """
+  Check if a workflow is complete (all stages done) and update status.
+  Called after a work item completes to detect workflow completion.
+  """
+  @spec check_completion(atom()) :: :ok
+  def check_completion(name) do
+    case get(name) do
+      %{status: :running} = workflow ->
+        items = Enum.map(workflow.stages, fn s -> Work.get(s.work_id) end)
+
+        cond do
+          Enum.all?(items, fn item -> item && item.status == :done end) ->
+            update_status(name, :completed)
+            PubSub.broadcast({:workflow, :completed, name})
+
+          Enum.any?(items, fn item -> item && item.status in [:failed, :blocked] end) ->
+            update_status(name, :failed)
+            PubSub.broadcast({:workflow, :failed, name})
+
+          true ->
+            :ok
+        end
+
+      _ ->
+        :ok
+    end
+  end
+
+  @doc """
+  Find which workflow (if any) a work item belongs to.
+  """
+  @spec workflow_for_item(atom()) :: atom() | nil
+  def workflow_for_item(item_id) do
+    case Work.get(item_id) do
+      %{metadata: %{workflow: name}} -> name
+      _ -> nil
+    end
+  end
+
+  # ── Serialization ──────────────────────────────────────────
+
+  @doc false
+  def to_map(%__MODULE__{} = workflow) do
+    %{
+      "name" => Atom.to_string(workflow.name),
+      "status" => Atom.to_string(workflow.status),
+      "created_at" => if(workflow.created_at, do: DateTime.to_iso8601(workflow.created_at)),
+      "stages" =>
+        Enum.map(workflow.stages, fn s ->
+          %{
+            "name" => Atom.to_string(s.name),
+            "work_id" => Atom.to_string(s.work_id),
+            "agent" => Atom.to_string(s.agent),
+            "title" => s.title,
+            "type" => Atom.to_string(s.type),
+            "priority" => s.priority,
+            "depends_on" => Enum.map(s.depends_on, &Atom.to_string/1),
+            "from_stages" => Enum.map(s.from_stages, &Atom.to_string/1),
+            "file_input" => s.file_input
+          }
+        end)
+    }
+  end
+
+  @doc false
+  def from_map(map) do
+    %__MODULE__{
+      name: String.to_atom(map["name"]),
+      status: String.to_atom(map["status"]),
+      created_at: parse_datetime(map["created_at"]),
+      stages:
+        Enum.map(map["stages"] || [], fn s ->
+          %{
+            name: String.to_atom(s["name"]),
+            work_id: String.to_atom(s["work_id"]),
+            agent: String.to_atom(s["agent"]),
+            title: s["title"],
+            type: String.to_atom(s["type"]),
+            priority: s["priority"] || 3,
+            depends_on: Enum.map(s["depends_on"] || [], &String.to_atom/1),
+            from_stages: Enum.map(s["from_stages"] || [], &String.to_atom/1),
+            file_input: s["file_input"]
+          }
+        end)
+    }
+  end
+
+  defp parse_datetime(nil), do: nil
+
+  defp parse_datetime(str) do
+    case DateTime.from_iso8601(str) do
+      {:ok, dt, _offset} -> dt
+      _ -> nil
+    end
+  end
+
+  # ── Internal ───────────────────────────────────────────────
+
+  defp parse_stages(workflow_name, stages) do
+    parsed =
+      Enum.map(stages, fn
+        {stage_name, agent, title} ->
+          parse_stage(workflow_name, stage_name, agent, title, [])
+
+        {stage_name, agent, title, opts} when is_list(opts) ->
+          parse_stage(workflow_name, stage_name, agent, title, opts)
+
+        other ->
+          {:error, {:invalid_stage, other}}
+      end)
+
+    case Enum.find(parsed, &match?({:error, _}, &1)) do
+      nil -> {:ok, parsed}
+      error -> error
+    end
+  end
+
+  defp parse_stage(workflow_name, stage_name, agent, title, opts) do
+    from = Keyword.get(opts, :from)
+    type = Keyword.get(opts, :type, :custom)
+    priority = Keyword.get(opts, :priority, 3)
+    work_id = :"#{workflow_name}_#{stage_name}"
+
+    {depends_on, from_stages, file_input} = resolve_from(workflow_name, from)
+
+    %{
+      name: stage_name,
+      work_id: work_id,
+      agent: agent,
+      title: title,
+      type: type,
+      priority: priority,
+      depends_on: depends_on,
+      from_stages: from_stages,
+      file_input: file_input
+    }
+  end
+
+  defp resolve_from(_wf, nil), do: {[], [], nil}
+
+  defp resolve_from(_wf, path) when is_binary(path), do: {[], [], path}
+
+  defp resolve_from(wf, stage) when is_atom(stage) do
+    id = :"#{wf}_#{stage}"
+    {[id], [id], nil}
+  end
+
+  defp resolve_from(wf, stages) when is_list(stages) do
+    ids = Enum.map(stages, &:"#{wf}_#{&1}")
+    {ids, ids, nil}
+  end
+
+  defp expand_stages(workflow) do
+    for stage <- workflow.stages do
+      spec = build_spec(stage)
+
+      Work.add(stage.work_id, stage.title,
+        type: stage.type,
+        priority: stage.priority,
+        spec: spec,
+        depends_on: stage.depends_on,
+        metadata: %{workflow: workflow.name, from_stages: stage.from_stages, agent: stage.agent}
+      )
+    end
+  end
+
+  defp build_spec(%{file_input: path} = stage) when is_binary(path) do
+    case File.read(path) do
+      {:ok, content} ->
+        if stage.from_stages != [] do
+          content
+        else
+          content
+        end
+
+      {:error, reason} ->
+        "Error reading #{path}: #{inspect(reason)}"
+    end
+  end
+
+  defp build_spec(_stage), do: nil
+
+  defp update_status(name, status) do
+    case get(name) do
+      nil -> :ok
+      workflow -> :ets.insert(@table, {name, %{workflow | status: status}})
+    end
+  end
+end

--- a/lib/agent_workshop/workshop.ex
+++ b/lib/agent_workshop/workshop.ex
@@ -85,7 +85,7 @@ defmodule AgentWorkshop.Workshop do
       Workshop (this module -- IEx helpers, no supervision duties)
   """
 
-  alias AgentWorkshop.{Budget, Profiles, PubSub, Scheduler, Store, Telemetry, Work}
+  alias AgentWorkshop.{Budget, Profiles, PubSub, Scheduler, Store, Telemetry, Work, Workflow}
   alias AgentWorkshop.Workshop.Display
 
   @table :agent_workshop_agents
@@ -163,7 +163,8 @@ defmodule AgentWorkshop.Workshop do
           AgentWorkshop.Store.table_name(),
           AgentWorkshop.Work.table_name(),
           AgentWorkshop.Budget.table_name(),
-          AgentWorkshop.Profiles.table_name()
+          AgentWorkshop.Profiles.table_name(),
+          Workflow.table_name()
         ] do
       if :ets.info(table) != :undefined, do: :ets.delete_all_objects(table)
     end
@@ -1422,6 +1423,173 @@ defmodule AgentWorkshop.Workshop do
 
     infos
   end
+
+  # ── Workflows ─────────────────────────────────────────────────
+
+  @doc """
+  Define a declarative workflow -- a sequence of stages that expand
+  into work board items with dependencies.
+
+  Each stage is a tuple: `{stage_name, agent, title}` or
+  `{stage_name, agent, title, opts}`.
+
+  ## Stage options
+
+    * `:from` - data source: a file path (string), a stage name (atom),
+      or a list of stage names (fan-in)
+    * `:type` - work board type (default: `:custom`)
+    * `:priority` - priority 1-5 (default: 3)
+
+  ## Example
+
+      workflow(:feature, [
+        {:plan, :planner, "Break this into tasks", from: "specs/feature.md"},
+        {:implement, :coder, "Implement the plan", from: :plan},
+        {:test, :tester, "Write tests", from: :implement},
+        {:review, :reviewer, "Review everything", from: [:implement, :test]}
+      ])
+  """
+  @spec workflow(atom(), list()) :: :ok | {:error, term()}
+  def workflow(name, stages) do
+    case Workflow.define(name, stages) do
+      :ok ->
+        stage_count = length(stages)
+        print_info("Workflow #{inspect(name)} defined (#{stage_count} stages)")
+        :ok
+
+      {:error, reason} ->
+        print_error("Cannot define workflow: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Run a workflow by expanding its stages into work board items.
+
+  Board workers will automatically pick up and execute the stages
+  in dependency order.
+
+  ## Example
+
+      run_workflow(:feature)
+  """
+  @spec run_workflow(atom()) :: :ok | {:error, term()}
+  def run_workflow(name) do
+    case Workflow.run(name) do
+      :ok ->
+        workflow = Workflow.get(name)
+        stage_count = length(workflow.stages)
+        print_info("Workflow #{inspect(name)} started (#{stage_count} stages)")
+        :ok
+
+      {:error, :not_found} ->
+        print_error("Unknown workflow #{inspect(name)}")
+        {:error, :not_found}
+
+      {:error, :already_running} ->
+        print_error("Workflow #{inspect(name)} is already running. Use reset_workflow/1 first.")
+        {:error, :already_running}
+    end
+  end
+
+  @doc """
+  Reset a workflow -- removes its work items and resets to :defined.
+
+  Use this to re-run a workflow or clear a failed run.
+
+  ## Example
+
+      reset_workflow(:feature)
+      run_workflow(:feature)
+  """
+  @spec reset_workflow(atom()) :: :ok | {:error, term()}
+  def reset_workflow(name) do
+    case Workflow.reset(name) do
+      :ok ->
+        print_info("Workflow #{inspect(name)} reset.")
+        :ok
+
+      {:error, :not_found} ->
+        print_error("Unknown workflow #{inspect(name)}")
+        {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Show workflow progress -- each stage with its current status.
+
+  ## Example
+
+      workflow_status(:feature)
+  """
+  @spec workflow_status(atom()) :: {Workflow.t(), [Work.t() | nil]} | {:error, term()}
+  def workflow_status(name) do
+    case Workflow.status(name) do
+      {:error, :not_found} ->
+        print_error("Unknown workflow #{inspect(name)}")
+        {:error, :not_found}
+
+      {workflow, items} ->
+        print_workflow_status(workflow, items)
+        {workflow, items}
+    end
+  end
+
+  @doc """
+  List all defined workflows.
+
+  ## Example
+
+      workflows()
+  """
+  @spec workflows() :: [Workflow.t()]
+  def workflows do
+    wfs = Workflow.list()
+
+    if wfs == [] do
+      print_info("No workflows defined.")
+    else
+      for wf <- wfs do
+        print_info("#{inspect(wf.name)}: #{wf.status} (#{length(wf.stages)} stages)")
+      end
+    end
+
+    wfs
+  end
+
+  defp print_workflow_status(workflow, items) do
+    status_label =
+      case workflow.status do
+        :defined -> "defined (not started)"
+        :running -> "running"
+        :completed -> "completed"
+        :failed -> "FAILED"
+      end
+
+    print_info("#{inspect(workflow.name)} workflow (#{status_label})")
+
+    Enum.zip(workflow.stages, items)
+    |> Enum.each(fn pair -> print_workflow_stage(pair) end)
+  end
+
+  defp print_workflow_stage({stage, nil}) do
+    print_info("  [pending] #{inspect(stage.name)} - #{stage.title}")
+  end
+
+  defp print_workflow_stage({stage, item}) do
+    status_str = format_work_status(item.status)
+    deps = if stage.depends_on != [], do: "  deps: #{inspect(stage.depends_on)}", else: ""
+    print_info("  [#{status_str}] #{inspect(stage.name)} - #{stage.title}#{deps}")
+  end
+
+  defp format_work_status(:new), do: "new"
+  defp format_work_status(:ready), do: "ready"
+  defp format_work_status(:claimed), do: "claimed"
+  defp format_work_status(:in_progress), do: "in_progress"
+  defp format_work_status(:done), do: "done"
+  defp format_work_status(:failed), do: "FAILED"
+  defp format_work_status(:blocked), do: "blocked"
+  defp format_work_status(:cancelled), do: "cancelled"
 
   # ── Interaction ───────────────────────────────────────────────
 

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: workflow
+description: Declarative multi-stage workflows. Define staged pipelines where each stage feeds its result to the next. Use for structured multi-agent tasks.
+license: MIT
+metadata:
+  author: joshrotenberg
+  version: "1.0"
+---
+
+# Workflow
+
+Declarative multi-stage pipelines. Define stages, run them, board workers execute in dependency order.
+
+## Defining a workflow
+
+```elixir
+workflow(:feature, [
+  {:plan, :planner, "Break this into tasks", from: "specs/feature.md"},
+  {:implement, :coder, "Implement the plan", from: :plan},
+  {:test, :tester, "Write tests", from: :implement},
+  {:review, :reviewer, "Review everything", from: [:implement, :test]}
+])
+```
+
+Each stage is `{name, agent, title}` or `{name, agent, title, opts}`.
+
+## Stage options
+
+- `from: "path/to/file.md"` -- read file content as input
+- `from: :stage_name` -- use previous stage's result as input
+- `from: [:a, :b]` -- fan-in: combine results from multiple stages
+- `type: :code` -- work board type (default: :custom)
+- `priority: 1` -- priority 1 (high) to 5 (low)
+
+## Running
+
+```elixir
+run_workflow(:feature)       # expand stages into work items
+workflow_status(:feature)    # check progress
+reset_workflow(:feature)     # clear and start over
+workflows()                  # list all workflows
+```
+
+## How it works
+
+- Each stage becomes a work board item with `depends_on`
+- Board workers claim and execute stages in order
+- Results from completed stages are injected into the next stage's prompt
+- If a stage fails, downstream stages are blocked
+- Workflow is complete when all stages are done
+
+## When to use
+
+- Multi-step features with clear ordering (plan, implement, test, review)
+- Pipelines where each step needs the previous step's output
+- Structured delegation across multiple agent roles
+- Repeatable processes you want to define once and run many times
+
+## Workflow vs board vs pipe
+
+- **Pipe**: manual, synchronous, you control each step
+- **Board**: self-organizing, agents claim work, no fixed ordering
+- **Workflow**: declarative, fixed stage ordering, automatic result flow

--- a/test/workflow_test.exs
+++ b/test/workflow_test.exs
@@ -1,0 +1,285 @@
+defmodule AgentWorkshop.WorkflowTest do
+  use ExUnit.Case, async: false
+
+  alias AgentWorkshop.{Work, Workflow, Workshop}
+
+  setup do
+    Workshop.stop()
+    on_exit(fn -> Workshop.stop() end)
+    :ok
+  end
+
+  describe "define/2" do
+    test "stores a workflow with parsed stages" do
+      assert :ok =
+               Workflow.define(:feature, [
+                 {:plan, :planner, "Plan the feature"},
+                 {:implement, :coder, "Implement it", from: :plan},
+                 {:test, :tester, "Test it", from: :implement}
+               ])
+
+      wf = Workflow.get(:feature)
+      assert wf.name == :feature
+      assert wf.status == :defined
+      assert length(wf.stages) == 3
+
+      [plan, impl, test_stage] = wf.stages
+      assert plan.work_id == :feature_plan
+      assert plan.depends_on == []
+      assert impl.work_id == :feature_implement
+      assert impl.depends_on == [:feature_plan]
+      assert impl.from_stages == [:feature_plan]
+      assert test_stage.depends_on == [:feature_implement]
+    end
+
+    test "handles fan-in dependencies" do
+      Workflow.define(:review, [
+        {:code, :coder, "Write code"},
+        {:test, :tester, "Write tests"},
+        {:review, :reviewer, "Review everything", from: [:code, :test]}
+      ])
+
+      wf = Workflow.get(:review)
+      review_stage = List.last(wf.stages)
+      assert review_stage.depends_on == [:review_code, :review_test]
+      assert review_stage.from_stages == [:review_code, :review_test]
+    end
+
+    test "handles file input" do
+      Workflow.define(:docs, [
+        {:write, :writer, "Write docs", from: "README.md"}
+      ])
+
+      wf = Workflow.get(:docs)
+      [stage] = wf.stages
+      assert stage.file_input == "README.md"
+      assert stage.depends_on == []
+    end
+
+    test "accepts type and priority options" do
+      Workflow.define(:typed, [
+        {:impl, :coder, "Implement", type: :code, priority: 1}
+      ])
+
+      wf = Workflow.get(:typed)
+      [stage] = wf.stages
+      assert stage.type == :code
+      assert stage.priority == 1
+    end
+
+    test "rejects invalid stage tuples" do
+      assert {:error, {:invalid_stage, :bad}} = Workflow.define(:bad, [:bad])
+    end
+  end
+
+  describe "run/1" do
+    test "expands stages into work items" do
+      Workflow.define(:pipeline, [
+        {:first, :agent_a, "First step"},
+        {:second, :agent_b, "Second step", from: :first}
+      ])
+
+      assert :ok = Workflow.run(:pipeline)
+
+      first = Work.get(:pipeline_first)
+      assert first != nil
+      assert first.title == "First step"
+      assert first.status == :ready
+      assert first.metadata.workflow == :pipeline
+
+      second = Work.get(:pipeline_second)
+      assert second != nil
+      assert second.depends_on == [:pipeline_first]
+      assert second.status == :new
+      assert second.metadata.from_stages == [:pipeline_first]
+    end
+
+    test "reads file input into spec" do
+      path = Path.join(System.tmp_dir!(), "workflow_test_input.md")
+      File.write!(path, "Feature spec content")
+      on_exit(fn -> File.rm(path) end)
+
+      Workflow.define(:file_wf, [
+        {:plan, :planner, "Plan from spec", from: path}
+      ])
+
+      Workflow.run(:file_wf)
+
+      item = Work.get(:file_wf_plan)
+      assert item.spec == "Feature spec content"
+    end
+
+    test "errors if workflow not found" do
+      assert {:error, :not_found} = Workflow.run(:nonexistent)
+    end
+
+    test "errors if already running" do
+      Workflow.define(:running, [{:step, :agent, "Do thing"}])
+      Workflow.run(:running)
+      assert {:error, :already_running} = Workflow.run(:running)
+    end
+
+    test "updates status to running" do
+      Workflow.define(:status_test, [{:step, :agent, "Do thing"}])
+      Workflow.run(:status_test)
+      assert Workflow.get(:status_test).status == :running
+    end
+  end
+
+  describe "reset/1" do
+    test "removes work items and resets status" do
+      Workflow.define(:resettable, [
+        {:a, :agent, "Step A"},
+        {:b, :agent, "Step B", from: :a}
+      ])
+
+      Workflow.run(:resettable)
+      assert Work.get(:resettable_a) != nil
+
+      assert :ok = Workflow.reset(:resettable)
+      assert Work.get(:resettable_a) == nil
+      assert Work.get(:resettable_b) == nil
+      assert Workflow.get(:resettable).status == :defined
+    end
+
+    test "allows re-running after reset" do
+      Workflow.define(:rerun, [{:step, :agent, "Do thing"}])
+      Workflow.run(:rerun)
+      Workflow.reset(:rerun)
+      assert :ok = Workflow.run(:rerun)
+      assert Workflow.get(:rerun).status == :running
+    end
+  end
+
+  describe "status/1" do
+    test "returns workflow and work items" do
+      Workflow.define(:st, [
+        {:a, :agent, "Step A"},
+        {:b, :agent, "Step B", from: :a}
+      ])
+
+      Workflow.run(:st)
+
+      {wf, items} = Workflow.status(:st)
+      assert wf.name == :st
+      assert length(items) == 2
+      assert Enum.all?(items, &(!is_nil(&1)))
+    end
+
+    test "errors for unknown workflow" do
+      assert {:error, :not_found} = Workflow.status(:nope)
+    end
+  end
+
+  describe "check_completion/1" do
+    test "marks workflow completed when all stages done" do
+      Workflow.define(:complete, [
+        {:a, :agent, "Step A"},
+        {:b, :agent, "Step B"}
+      ])
+
+      Workflow.run(:complete)
+
+      # Manually complete both items
+      Work.claim(:complete_a, :test_agent)
+      Work.complete(:complete_a, "done A")
+      Work.claim(:complete_b, :test_agent)
+      Work.complete(:complete_b, "done B")
+
+      Workflow.check_completion(:complete)
+      assert Workflow.get(:complete).status == :completed
+    end
+
+    test "marks workflow failed when a stage fails" do
+      Workflow.define(:fail_wf, [
+        {:a, :agent, "Step A"},
+        {:b, :agent, "Step B", from: :a}
+      ])
+
+      Workflow.run(:fail_wf)
+
+      Work.claim(:fail_wf_a, :test_agent)
+      Work.fail(:fail_wf_a, "broken")
+
+      Workflow.check_completion(:fail_wf)
+      assert Workflow.get(:fail_wf).status == :failed
+
+      # Dependent should be blocked
+      assert Work.get(:fail_wf_b).status == :blocked
+    end
+  end
+
+  describe "workflow_for_item/1" do
+    test "finds workflow for a work item" do
+      Workflow.define(:lookup, [{:step, :agent, "Do thing"}])
+      Workflow.run(:lookup)
+
+      assert Workflow.workflow_for_item(:lookup_step) == :lookup
+    end
+
+    test "returns nil for non-workflow items" do
+      Work.add(:standalone, "Regular work", type: :code)
+      assert Workflow.workflow_for_item(:standalone) == nil
+      Work.remove(:standalone)
+    end
+  end
+
+  describe "list/0" do
+    test "lists all workflows" do
+      Workflow.define(:wf_a, [{:s, :a, "A"}])
+      Workflow.define(:wf_b, [{:s, :a, "B"}])
+
+      wfs = Workflow.list()
+      names = Enum.map(wfs, & &1.name)
+      assert :wf_a in names
+      assert :wf_b in names
+    end
+  end
+
+  describe "serialization" do
+    test "round-trips through to_map/from_map" do
+      Workflow.define(:serial, [
+        {:plan, :planner, "Plan", from: "spec.md"},
+        {:impl, :coder, "Implement", from: :plan, type: :code, priority: 1}
+      ])
+
+      wf = Workflow.get(:serial)
+      map = Workflow.to_map(wf)
+      restored = Workflow.from_map(map)
+
+      assert restored.name == :serial
+      assert restored.status == :defined
+      assert length(restored.stages) == 2
+
+      [plan, impl] = restored.stages
+      assert plan.file_input == "spec.md"
+      assert impl.depends_on == [:serial_plan]
+      assert impl.type == :code
+      assert impl.priority == 1
+    end
+  end
+
+  describe "build_prompt injection" do
+    test "injects dependency results into prompt" do
+      Workflow.define(:prompt_test, [
+        {:a, :agent, "Step A"},
+        {:b, :agent, "Step B", from: :a}
+      ])
+
+      Workflow.run(:prompt_test)
+
+      # Complete step A with a result
+      Work.claim(:prompt_test_a, :test_agent)
+      Work.complete(:prompt_test_a, "Result from step A")
+
+      # Step B should now be ready
+      item_b = Work.get(:prompt_test_b)
+      assert item_b.status == :ready
+
+      # Test the build_prompt function via the BoardWorker module
+      # We can't call the private function directly, but we can verify
+      # the metadata is set correctly for the board worker to use
+      assert item_b.metadata.from_stages == [:prompt_test_a]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `AgentWorkshop.Workflow` module for defining multi-stage pipelines as data
- Each stage expands into a work board item with `depends_on` -- board workers execute in dependency order
- Results from completed stages are automatically injected into downstream stage prompts via `from_stages` metadata
- Failure propagation: failed stage blocks all downstream stages and marks workflow as `:failed`
- `reset_workflow/1` clears work items for re-runs
- Persistence support (`workflows.json`), workflow skill, and example config
- 21 new tests (153 total, 0 failures)

### New API
```elixir
workflow(:feature, [
  {:plan, :planner, "Break this into tasks", from: "specs/feature.md"},
  {:implement, :coder, "Implement the plan", from: :plan, type: :code},
  {:test, :tester, "Write tests", from: :implement},
  {:review, :reviewer, "Review everything", from: [:implement, :test]}
])

run_workflow(:feature)
workflow_status(:feature)
reset_workflow(:feature)
```

Closes #76

## Test plan
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean
- [x] 153 tests, 0 failures
- [ ] CI passes (Elixir 1.19 / OTP 28)