### PR TITLE
docs: hex docs guides and ex_doc config for v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ or any CLI-based LLM through a pluggable backend.
 ```elixir
 def deps do
   [
-    {:agent_workshop, "~> 0.2"},
+    {:agent_workshop, "~> 0.3"},
 
     # Pick your backend(s):
     {:claude_wrapper, "~> 0.4"},   # for Claude Code CLI
@@ -122,6 +122,21 @@ work(:feature, "Implement checkout command", type: :code, priority: 1,
 work(:feature_review, "Review checkout", type: :review, depends_on: [:feature])
 # coder claims feature, implements it, marks done
 # feature_review auto-unblocks, reviewer claims it
+```
+
+### 4. Declarative workflows
+
+```elixir
+workflow(:feature, [
+  {:plan, :planner, "Break this into tasks", from: "specs/feature.md"},
+  {:implement, :coder, "Implement the plan", from: :plan, type: :code},
+  {:test, :tester, "Write tests", from: :implement, type: :test},
+  {:review, :reviewer, "Review everything", from: [:implement, :test], type: :review}
+])
+
+run_workflow(:feature)
+workflow_status(:feature)
+reset_workflow(:feature)    # clear and re-run
 ```
 
 ## Work board
@@ -235,6 +250,7 @@ watch()                        # live event stream
 events()                       # event history
 workers()                      # board worker status
 board()                        # work board
+workflows()                    # workflow status
 ```
 
 ## Backends

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -1,0 +1,324 @@
+# Configuration Reference
+
+All Workshop configuration is set through `configure/1` or individual
+functions. Configuration is stored in `:persistent_term` for zero-cost reads.
+
+## configure/1
+
+```elixir
+configure(
+  backend: AgentWorkshop.Backends.Claude,
+  backend_config: ClaudeWrapper.Config.new(working_dir: "."),
+  model: "sonnet",
+  permission_mode: :bypass_permissions,
+  context: "Elixir project. Run mix test before committing.",
+  max_cost_usd: 10.00,
+  mcp: [port: 4222],
+  dashboard: true,
+  persistence: true,
+  git_context: true
+)
+```
+
+### Required options
+
+| Option | Description |
+|--------|-------------|
+| `:backend` | Backend module (e.g., `AgentWorkshop.Backends.Claude`) |
+| `:backend_config` | Backend-specific configuration struct |
+
+### Agent defaults
+
+These apply to all agents unless overridden per-agent:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:model` | (none) | LLM model name (e.g., `"sonnet"`, `"opus"`, `"haiku"`) |
+| `:permission_mode` | `:auto` | `:default`, `:accept_edits`, `:bypass_permissions`, `:dont_ask`, `:plan`, `:auto` |
+| `:context` | (none) | System prompt prepended to all agents |
+| `:max_cost_usd` | (none) | Global cost budget across all agents |
+
+### Feature toggles
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:mcp` | (none) | Start MCP server. Pass `[port: 4222]` or just `true` for default port. |
+| `:dashboard` | `false` | Start LiveView dashboard on port 4223 |
+| `:persistence` | `false` | Enable disk persistence. Pass `true` for `.agent_workshop/` or a path string. |
+| `:git_context` | `false` | Inject git branch, status, and recent commits into agent prompts |
+
+## Agent options
+
+Options passed to `agent/3` override global defaults:
+
+```elixir
+agent(:impl, "You write clean, well-tested code.",
+  model: "sonnet",
+  max_turns: 15,
+  timeout: :timer.minutes(5),
+  max_cost_usd: 2.00,
+  allowed_tools: ["Read", "Edit", "Write", "Bash"],
+  skill: :pair,
+  workshop_tools: true
+)
+```
+
+| Option | Description |
+|--------|-------------|
+| `:model` | Override model for this agent |
+| `:max_turns` | Maximum conversation turns |
+| `:timeout` | Response timeout in milliseconds |
+| `:max_cost_usd` | Per-agent cost budget |
+| `:allowed_tools` | Restrict which tools the agent can use |
+| `:skill` | Assign a skill from `skills/` (e.g., `:pair`, `:board`) |
+| `:workshop_tools` | `true` to give the agent MCP access to Workshop |
+| `:permission_mode` | Override permission mode for this agent |
+
+## Profiles
+
+Profiles are reusable agent templates. Define once, create many agents:
+
+```elixir
+profile(:coder, "You write clean, well-tested code.",
+  model: "sonnet",
+  max_turns: 15,
+  timeout: :timer.minutes(5))
+
+profile(:reviewer, "Review for correctness. Do not modify files.",
+  model: "opus",
+  allowed_tools: ["Read", "Bash"])
+
+# Create agents from profiles
+from_profile(:coder, :dev_1)
+from_profile(:coder, :dev_2)
+from_profile(:reviewer, :rev_1)
+
+# Or use profiles with board workers
+board_worker(:dev_1, :code, profile: :coder, interval: :timer.seconds(30))
+```
+
+Manage profiles:
+
+```elixir
+profiles()              # list all profiles
+```
+
+## Backends
+
+A backend implements `AgentWorkshop.Backend` -- 8 callbacks for starting
+sessions, sending messages, and reading state.
+
+### Claude (recommended)
+
+```elixir
+configure(
+  backend: AgentWorkshop.Backends.Claude,
+  backend_config: ClaudeWrapper.Config.new(working_dir: ".")
+)
+```
+
+The Claude backend wraps the Claude Code CLI via `claude_wrapper`. Backend
+config options are passed through to `ClaudeWrapper.Config`.
+
+### Codex
+
+```elixir
+configure(
+  backend: AgentWorkshop.Backends.Codex,
+  backend_config: CodexWrapper.Config.new(working_dir: ".")
+)
+```
+
+### Custom backends
+
+Implement the `AgentWorkshop.Backend` behaviour:
+
+```elixir
+defmodule MyBackend do
+  @behaviour AgentWorkshop.Backend
+
+  @impl true
+  def start_session(config, opts), do: ...
+  @impl true
+  def send_message(pid, prompt, opts), do: ...
+  @impl true
+  def session_id(pid), do: ...
+  @impl true
+  def history(pid), do: ...
+  @impl true
+  def total_cost(pid), do: ...
+  @impl true
+  def turn_count(pid), do: ...
+  @impl true
+  def last_result(pid), do: ...
+  @impl true
+  def stop_session(pid), do: ...
+end
+```
+
+## Budgets
+
+Set cost limits globally or per-agent:
+
+```elixir
+# Global budget
+configure(max_cost_usd: 10.00)
+
+# Per-agent budget
+agent(:impl, "Coder", max_cost_usd: 2.00)
+
+# Check budgets
+budget()         # global remaining
+budget(:impl)    # per-agent
+cost()           # itemized by agent
+total_cost()     # total across all agents
+```
+
+When a budget is exceeded, the agent's next message returns
+`{:error, :budget_exceeded}`.
+
+## Persistence
+
+Persist work board, store, and events to disk:
+
+```elixir
+configure(persistence: true)              # .agent_workshop/ in cwd
+configure(persistence: "/path/to/dir")    # custom directory
+```
+
+### Files written
+
+- `work.json` -- full work board snapshot
+- `store.json` -- key-value store snapshot
+- `workflows.json` -- workflow definitions
+- `events.jsonl` -- append-only event log
+
+Writes are debounced (100ms) and triggered by PubSub events. On startup
+with persistence enabled, saved state is loaded back into ETS.
+
+## Git context
+
+Automatically inject git state into agent prompts:
+
+```elixir
+configure(git_context: true)
+```
+
+This appends the current branch, working tree status, and recent commits
+to each agent's system prompt. The context is refreshed on each message.
+Requires the optional `{:git, "~> 0.2"}` dependency.
+
+```elixir
+# Manual access
+git_summary()    # structured map of git state
+git_diff()       # current diff text
+```
+
+## Scheduling
+
+Run prompts on a recurring interval:
+
+```elixir
+every(:monitor, "Check CI status and report",
+  interval: :timer.minutes(5))
+
+schedules()         # list active schedules
+cancel(:monitor)    # stop a schedule
+```
+
+The scheduler skips ticks when the agent is busy.
+
+## Event log
+
+All Workshop activity is logged to a ring buffer:
+
+```elixir
+watch()              # print events live (PubSub subscription)
+unwatch()            # stop watching
+events()             # last 20 events
+events(last: 50)     # more history
+clear_events()       # reset the ring buffer
+```
+
+Events include agent creation/dismissal, ask/cast completions, work board
+changes, board worker claims, and workflow state transitions.
+
+## Shared store
+
+Key-value scratchpad for agent coordination:
+
+```elixir
+put(:spec, "LRU cache with TTL support")
+get(:spec)
+store()              # show all entries
+store_keys()         # list keys
+delete(:spec)
+```
+
+Values are stored in ETS and optionally persisted to disk.
+
+## Skills
+
+Skills follow the [agentskills.io](https://agentskills.io) open standard.
+Skill content is injected into the agent's system prompt:
+
+```elixir
+agent(:impl, "Coder", skill: :pair)
+```
+
+Built-in skills (in `skills/`):
+
+| Skill | Description |
+|-------|-------------|
+| `:solo` | Single agent working alone |
+| `:pair` | Implement + review pattern |
+| `:board` | Work board driven development |
+| `:"board-worker"` | Polling agent pattern |
+| `:orchestrator` | Team coordinator |
+| `:monitor` | Scheduled health checks |
+| `:mixed` | Multiple backend agents |
+| `:workflow` | Multi-stage pipelines |
+| `:github` | GitHub integration via gh CLI |
+
+## Log level
+
+Control Workshop log verbosity:
+
+```elixir
+log_level(:warning)    # quiet -- only warnings and errors
+log_level(:info)       # default
+log_level(:debug)      # verbose -- see send/receive for every message
+```
+
+## Teardown
+
+```elixir
+reset(:impl)       # clear one agent's conversation
+dismiss(:impl)     # remove an agent
+reset_all()        # stop all agents, clear config
+stop()             # full teardown (agents, tables, config)
+```
+
+## Examples
+
+The `examples/` directory contains ready-to-use setup files:
+
+| File | Pattern |
+|------|---------|
+| `solo.exs` | Single agent |
+| `pair.exs` | Implement + review |
+| `board.exs` | Board workers |
+| `workflow.exs` | Declarative workflow |
+| `orchestrator.exs` | Orchestrator with MCP |
+| `monitor.exs` | Scheduled monitoring |
+| `budget.exs` | Cost budgets |
+| `mixed.exs` | Multiple backends |
+| `team.exs` | Multi-agent team |
+| `github_sync.exs` | GitHub issue sync |
+| `dogfood.exs` | Self-referential setup |
+
+Load any example:
+
+```elixir
+load("examples/board.exs")
+```

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -3,6 +3,28 @@
 AgentWorkshop is a multi-agent orchestration library for Elixir. You create
 LLM agents, give them roles, and coordinate their work -- all from IEx.
 
+## Prerequisites
+
+AgentWorkshop runs CLI-based LLM tools on your behalf. You need at least one
+installed and authenticated:
+
+- **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** -- `claude`
+  CLI, authenticated via `claude login`. This is the recommended backend.
+- **[OpenAI Codex](https://github.com/openai/codex)** -- `codex` CLI, with
+  `OPENAI_API_KEY` set. Alternative backend.
+
+Agents run these CLIs as your user, with your credentials and permissions.
+They can read and write files, run shell commands, and make git commits --
+just like you would from the terminal. Use `permission_mode` and
+`allowed_tools` to control what agents can do.
+
+For source control features (git context injection, worktrees for parallel
+agents, GitHub integration):
+
+- **git** -- any recent version
+- **[gh](https://cli.github.com/)** -- GitHub CLI, authenticated via
+  `gh auth login`. Needed for the GitHub integration skill.
+
 ## Installation
 
 Add `agent_workshop` and a backend to your `mix.exs`:

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -1,0 +1,143 @@
+# Getting Started
+
+AgentWorkshop is a multi-agent orchestration library for Elixir. You create
+LLM agents, give them roles, and coordinate their work -- all from IEx.
+
+## Installation
+
+Add `agent_workshop` and a backend to your `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:agent_workshop, "~> 0.3"},
+    {:claude_wrapper, "~> 0.4"}  # Claude Code CLI backend
+  ]
+end
+```
+
+Optional dependencies unlock additional features:
+
+```elixir
+# MCP server (expose Workshop as tools for other agents)
+{:anubis_mcp, "~> 1.0"},
+{:bandit, "~> 1.0"},
+{:plug, "~> 1.16"},
+
+# LiveView dashboard (real-time web UI)
+{:phoenix, "~> 1.7"},
+{:phoenix_live_view, "~> 1.0"},
+{:phoenix_html, "~> 4.0"},
+
+# Git context injection
+{:git, "~> 0.2"},
+
+# Alternative backend
+{:codex_wrapper, "~> 0.2"}  # OpenAI Codex CLI
+```
+
+## First session
+
+Start IEx in your project:
+
+```
+$ iex -S mix
+```
+
+Import the Workshop API and configure your backend:
+
+```elixir
+import AgentWorkshop.Workshop
+
+configure(
+  backend: AgentWorkshop.Backends.Claude,
+  backend_config: ClaudeWrapper.Config.new(working_dir: "."),
+  model: "sonnet",
+  permission_mode: :bypass_permissions,
+  context: "Elixir project. Run mix test before committing."
+)
+```
+
+## Creating agents
+
+Each agent has a name and a role description that becomes its system prompt:
+
+```elixir
+agent(:impl, "You write clean, well-tested code.", max_turns: 15)
+agent(:reviewer, "You review code. Do not modify files.",
+  model: "opus", allowed_tools: ["Read", "Bash"])
+```
+
+## Talking to agents
+
+`ask/2` sends a message and waits for a response:
+
+```elixir
+ask(:impl, "Implement caching for the user lookup")
+```
+
+`cast/2` sends a message and returns immediately. The agent works in the
+background:
+
+```elixir
+cast(:impl, "Implement the retry logic from issue #12")
+status()       # see who's working
+await(:impl)   # wait for the result
+```
+
+## Piping results
+
+Chain agents together with `pipe/3`. The result from one agent is forwarded
+to the next:
+
+```elixir
+ask(:impl, "Implement caching")
+|> pipe(:reviewer, "Review for edge cases")
+|> pipe(:impl, "Address the review feedback")
+```
+
+## Setup files
+
+Instead of configuring manually each time, put your setup in `.workshop.exs`:
+
+```elixir
+# .workshop.exs -- auto-loaded on iex -S mix
+configure(
+  backend: AgentWorkshop.Backends.Claude,
+  backend_config: ClaudeWrapper.Config.new(working_dir: "."),
+  model: "sonnet",
+  permission_mode: :bypass_permissions,
+  context: "My project description.",
+  mcp: [port: 4222]
+)
+
+profile(:coder, "You write clean code.", max_turns: 15)
+profile(:reviewer, "Review only.", model: "opus", allowed_tools: ["Read", "Bash"])
+
+agent(:orchestrator, "You coordinate agents.",
+  workshop_tools: true, model: "sonnet", max_turns: 30)
+```
+
+Load a different setup file at any time:
+
+```elixir
+load("examples/board.exs")
+```
+
+## Checking on things
+
+```elixir
+status()           # agent dashboard
+info(:impl)        # detailed info for one agent
+result(:impl)      # last response text
+cost()             # cost breakdown by agent
+total_cost()       # total spend
+history(:impl)     # full conversation
+```
+
+## Next steps
+
+- [Orchestration Patterns](orchestration-patterns.md) -- three ways to coordinate agents
+- [Work Board and Workflows](work-board.md) -- structured task management
+- [MCP Server](mcp-server.md) -- expose Workshop as tools
+- [Configuration Reference](configuration.md) -- all options explained

--- a/guides/mcp-server.md
+++ b/guides/mcp-server.md
@@ -1,0 +1,146 @@
+# MCP Server
+
+AgentWorkshop includes an MCP (Model Context Protocol) server that exposes
+the Workshop API as tools. Any MCP client -- including Claude Code, other
+agents, or custom clients -- can connect and manage agents, work items,
+and coordination.
+
+## Setup
+
+### Dependencies
+
+Add the MCP dependencies to your `mix.exs`:
+
+```elixir
+{:anubis_mcp, "~> 1.0"},
+{:bandit, "~> 1.0"},
+{:plug, "~> 1.16"}
+```
+
+### Starting the server
+
+Start the MCP server from IEx or a setup file:
+
+```elixir
+# From IEx
+mcp_server(port: 4222)
+
+# Or via configure/1 (auto-starts with your setup)
+configure(
+  backend: AgentWorkshop.Backends.Claude,
+  backend_config: ClaudeWrapper.Config.new(working_dir: "."),
+  mcp: [port: 4222]
+)
+```
+
+### Client configuration
+
+Point your MCP client at the server. For Claude Code, add to `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "workshop": {
+      "type": "http",
+      "url": "http://localhost:4222/mcp"
+    }
+  }
+}
+```
+
+## Available tools (21)
+
+### Agent management (6 tools)
+
+| Tool | Description |
+|------|-------------|
+| `configure` | Set backend, model, context, and other global options |
+| `create_agent` | Create an agent with a name and role |
+| `from_profile` | Create an agent from a saved profile |
+| `agents` | List all agents and their status |
+| `reset` | Clear an agent's conversation (keep role and config) |
+| `dismiss` | Remove an agent entirely |
+
+### Interaction (6 tools)
+
+| Tool | Description |
+|------|-------------|
+| `ask` | Send a message and wait for the response |
+| `cast` | Send a message asynchronously |
+| `await` | Wait for an async agent to finish |
+| `await_all` | Wait for all busy agents to finish |
+| `pipe` | Forward one agent's result to another |
+| `fan` | Send the same message to multiple agents |
+
+### Work board (5 tools)
+
+| Tool | Description |
+|------|-------------|
+| `add_work` | Add a work item to the board |
+| `board` | List work items (optionally filtered) |
+| `claim_work` | Claim a work item for an agent |
+| `complete_work` | Mark a work item as done |
+| `fail_work` | Mark a work item as failed |
+
+### Observability (4 tools)
+
+| Tool | Description |
+|------|-------------|
+| `status` | Agent dashboard (names, status, cost, turns) |
+| `result` | Get an agent's last response |
+| `info` | Detailed info for one agent |
+| `cost` | Cost breakdown across all agents |
+
+## Orchestrator pattern
+
+The MCP server enables the orchestrator pattern -- an agent with
+`workshop_tools: true` that can create and manage other agents:
+
+```elixir
+profile(:coder, "You write clean code.", max_turns: 15)
+profile(:reviewer, "Review only.", model: "opus")
+
+agent(:orchestrator, "You coordinate agents to build features.",
+  workshop_tools: true, model: "sonnet", max_turns: 30)
+
+cast(:orchestrator, "Build the auth module with review")
+```
+
+When an agent has `workshop_tools: true`, its backend config is automatically
+set up to connect to the MCP server. The orchestrator can then:
+
+1. Create agents from profiles (`from_profile`)
+2. Send them work (`ask`, `cast`)
+3. Monitor progress (`status`, `result`)
+4. Manage the work board (`add_work`, `board`, `complete_work`)
+5. Clean up when done (`dismiss`)
+
+The `AGENTS.md` file at the project root provides guidance to orchestrator
+agents about available tools and recommended patterns.
+
+## Skills for MCP-aware agents
+
+Agents with `workshop_tools: true` automatically receive the `AGENTS.md`
+guidance. You can also assign skills for specific patterns:
+
+```elixir
+agent(:coordinator, "You manage the team.",
+  workshop_tools: true, skill: :orchestrator)
+```
+
+See `skills/orchestrator/SKILL.md` for the orchestrator skill guide.
+
+## Dashboard
+
+If you have the Phoenix LiveView dependencies installed, you can also
+start the web dashboard alongside the MCP server:
+
+```elixir
+configure(
+  mcp: [port: 4222],
+  dashboard: true
+)
+```
+
+The dashboard runs on port 4223 and provides real-time views of agents,
+the work board, workers, configuration, git status, and a reference guide.

--- a/guides/orchestration-patterns.md
+++ b/guides/orchestration-patterns.md
@@ -1,0 +1,151 @@
+# Orchestration Patterns
+
+AgentWorkshop supports three patterns for coordinating agents. Each builds on
+the previous -- start simple and add structure as your tasks grow.
+
+## 1. Direct (ask/cast/pipe)
+
+You control the flow. Send messages, read results, decide what happens next.
+
+```elixir
+# Synchronous -- blocks until the agent responds
+ask(:impl, "Implement caching for user lookups")
+
+# Asynchronous -- agent works in background
+cast(:impl, "Implement the retry module")
+cast(:tests, "Write property-based tests for lib/encoder.ex")
+status()        # see who's working
+await_all()     # wait for everyone
+
+# Chaining -- pipe results from one agent to another
+ask(:impl, "Implement caching")
+|> pipe(:reviewer, "Review for correctness")
+|> pipe(:impl, "Address the review feedback")
+
+# Fan out -- same question to multiple agents
+fan("What issues do you see in lib/retry.ex?", [:impl, :reviewer])
+await_all()
+result(:impl)       # one perspective
+result(:reviewer)    # another perspective
+```
+
+**When to use:** Exploratory work, one-off tasks, debugging sessions. You're
+actively driving the conversation and making judgment calls between steps.
+
+## 2. Orchestrator (workshop_tools + profiles)
+
+A dedicated agent creates and manages other agents. You give it a high-level
+goal and it breaks it down, delegates, and coordinates.
+
+```elixir
+# Define reusable agent templates
+profile(:coder, "You write clean, well-tested code.",
+  max_turns: 15, timeout: :timer.minutes(5))
+profile(:reviewer, "Review for correctness. Do not modify files.",
+  model: "opus", allowed_tools: ["Read", "Bash"])
+
+# Create the orchestrator with MCP access to Workshop
+agent(:orchestrator, "You coordinate a team of agents to build features.",
+  workshop_tools: true, model: "sonnet", max_turns: 30)
+
+# Give it a goal -- it handles the rest
+cast(:orchestrator, """
+Build the auth module:
+1. Create a coder from the :coder profile
+2. Have it implement JWT-based authentication
+3. Create a reviewer from the :reviewer profile
+4. Have it review the implementation
+5. Address any feedback
+""")
+```
+
+The orchestrator has access to 21 MCP tools for creating agents, sending
+messages, managing the work board, and checking status. See the
+[MCP Server guide](mcp-server.md) for the full tool list.
+
+**When to use:** Multi-step features where you want an agent to manage the
+workflow. Good for tasks with clear success criteria that don't need human
+judgment at each step.
+
+## 3. Board workers (self-organizing)
+
+Post work items to a board. Workers poll for items matching their type,
+claim them, execute them, and mark them done. Dependencies handle ordering.
+
+```elixir
+# Define roles
+profile(:coder, "You write clean code.", max_turns: 15)
+profile(:reviewer, "Review only.", model: "opus")
+
+# Start workers -- they poll the board automatically
+board_worker(:dev_1, :code, profile: :coder,
+  interval: :timer.seconds(30), worktree: true)
+board_worker(:dev_2, :code, profile: :coder,
+  interval: :timer.seconds(30), worktree: true)
+board_worker(:rev_1, :review, profile: :reviewer,
+  interval: :timer.seconds(30))
+
+# Post work -- workers pick it up
+work(:auth, "Implement auth module", type: :code, priority: 1,
+  spec: "JWT-based auth with login/logout endpoints")
+work(:auth_review, "Review auth", type: :review, depends_on: [:auth])
+
+work(:api, "Implement API routes", type: :code, priority: 2,
+  spec: "REST endpoints for users and posts")
+work(:api_review, "Review API", type: :review, depends_on: [:api])
+
+# Watch it happen
+watch()          # live event stream
+board()          # current state
+workers()        # worker status
+```
+
+Workers use `worktree: true` to work in isolated git worktrees, so multiple
+coders can work on different items in parallel without conflicts.
+
+**When to use:** Multiple independent tasks, parallel execution, CI-like
+pipelines. The board handles coordination so you just post work and observe.
+
+## 4. Declarative workflows
+
+Define multi-stage pipelines as data. Each stage runs an agent and feeds
+its result to the next. Under the hood, workflows expand into board items
+with dependencies.
+
+```elixir
+workflow(:feature, [
+  {:plan, :planner, "Break this into tasks", from: "specs/feature.md"},
+  {:implement, :coder, "Implement the plan", from: :plan, type: :code},
+  {:test, :tester, "Write tests", from: :implement, type: :test},
+  {:review, :reviewer, "Review everything", from: [:implement, :test], type: :review}
+])
+
+run_workflow(:feature)
+workflow_status(:feature)
+```
+
+Workflows support file inputs (`from: "path"`), stage chaining (`from: :stage`),
+and fan-in (`from: [:a, :b]`). See the [Work Board guide](work-board.md) for
+details.
+
+**When to use:** Repeatable processes with clear stages. Define once, run
+many times. Good for structured development workflows (plan, implement,
+test, review).
+
+## Choosing a pattern
+
+| Pattern | Control | Automation | Complexity |
+|---------|---------|------------|------------|
+| Direct | Full | None | Low |
+| Orchestrator | Delegated | High | Medium |
+| Board workers | Observed | Full | Medium |
+| Workflows | Declarative | Full | Low |
+
+Start with **direct** for exploration. Move to **workflows** when you have a
+repeatable process. Use **board workers** when you need parallel execution.
+Use an **orchestrator** when the task requires dynamic judgment calls that
+you don't want to make yourself.
+
+These patterns compose. An orchestrator can post work to the board. A workflow
+can include stages that use orchestrator agents. Board workers execute
+workflow stages automatically.

--- a/guides/work-board.md
+++ b/guides/work-board.md
@@ -1,0 +1,202 @@
+# Work Board and Workflows
+
+The work board is a structured task tracker. Work items flow through a
+lifecycle, dependencies handle ordering, and board workers execute items
+automatically.
+
+## Work items
+
+A work item has a name, title, type, and optional spec:
+
+```elixir
+work(:cache, "Implement LRU cache",
+  type: :code,
+  priority: 1,
+  spec: "LRU cache with configurable max size and TTL per entry")
+```
+
+### Types
+
+Work types let you route items to the right workers:
+
+- `:code` -- implementation work
+- `:review` -- code review
+- `:test` -- test writing
+- `:docs` -- documentation
+- `:deploy` -- deployment tasks
+- `:triage` -- issue triage
+- `:custom` -- anything else (default)
+
+### Priority
+
+Priority ranges from 1 (highest) to 5 (lowest). Default is 3. Board workers
+claim the highest-priority ready item first.
+
+## Lifecycle
+
+Every work item moves through these states:
+
+```
+new --> ready --> claimed --> in_progress --> done
+                                          --> failed
+              ^
+        blocked (unmet dependency)
+        cancelled
+```
+
+- **new** -- has unmet dependencies, waiting
+- **ready** -- all dependencies satisfied, available for claim
+- **claimed** -- an agent claimed it but hasn't started yet
+- **in_progress** -- actively being worked on
+- **done** -- completed successfully, unblocks downstream
+- **failed** -- execution failed, blocks downstream
+- **blocked** -- a dependency failed or was cancelled
+- **cancelled** -- manually cancelled
+
+## Dependencies
+
+Items can depend on other items. Dependents stay in `:new` until all
+dependencies reach `:done`:
+
+```elixir
+work(:cache, "Implement LRU cache", type: :code)
+work(:cache_tests, "Write cache tests", type: :test, depends_on: [:cache])
+work(:cache_review, "Review cache", type: :review, depends_on: [:cache])
+```
+
+When `:cache` completes, both `:cache_tests` and `:cache_review` automatically
+transition to `:ready`. If `:cache` fails, both are `:blocked`.
+
+## Board commands
+
+```elixir
+board()                    # show all items
+board(status: :ready)      # filter by status
+board(type: :code)         # filter by type
+
+claim_work(:cache, :impl)  # manually claim for an agent
+start_work(:cache)         # mark in progress
+complete_work(:cache, "Implemented with GenServer-backed LRU")
+fail_work(:cache, "tests broken")
+cancel_work(:cache)        # cancel and block dependents
+```
+
+## Board workers
+
+A board worker combines an agent profile with a poll loop. It watches the
+board for ready items matching its type, claims them, executes them, and
+marks them done or failed.
+
+```elixir
+profile(:coder, "You write clean code.", max_turns: 15)
+profile(:reviewer, "Review only.", model: "opus")
+
+board_worker(:dev_1, :code,
+  profile: :coder,
+  interval: :timer.seconds(30),
+  worktree: true)
+
+board_worker(:rev_1, :review,
+  profile: :reviewer,
+  interval: :timer.seconds(30))
+```
+
+### Options
+
+- `:profile` (required) -- profile to create the agent from
+- `:interval` -- poll interval in milliseconds (default: 60,000)
+- `:worktree` -- when `true`, the agent works in an isolated git worktree
+
+### Monitoring
+
+```elixir
+workers()    # show all workers and their current item
+watch()      # live event stream (claims, completions, failures)
+events()     # recent event history
+```
+
+Workers reset their agent session between items so each task starts with
+a fresh conversation.
+
+## Declarative workflows
+
+Workflows define multi-stage pipelines as data. Each stage is a work item
+with automatic dependency wiring and result flow.
+
+### Defining a workflow
+
+```elixir
+workflow(:feature, [
+  {:plan, :planner, "Break this into tasks", from: "specs/feature.md"},
+  {:implement, :coder, "Implement the plan", from: :plan, type: :code},
+  {:test, :tester, "Write tests", from: :implement, type: :test},
+  {:review, :reviewer, "Review everything", from: [:implement, :test], type: :review}
+])
+```
+
+Each stage is a tuple: `{name, agent, title}` or `{name, agent, title, opts}`.
+
+### Stage options
+
+- `from: "path/to/file.md"` -- read file content and inject as the stage's spec
+- `from: :stage_name` -- the previous stage's result is injected into the prompt
+- `from: [:a, :b]` -- fan-in: combine results from multiple stages
+- `type: :code` -- work board type for routing to the right worker
+- `priority: 1` -- priority (default: 3)
+
+### Running
+
+```elixir
+run_workflow(:feature)       # expand stages into work items
+workflow_status(:feature)    # check progress
+workflows()                  # list all workflows
+```
+
+### Result flow
+
+When a stage completes, its result is automatically injected into the
+prompt for any dependent stage. Board workers handle this transparently --
+the downstream stage sees a "Previous stage results" section in its prompt.
+
+### Reset and re-run
+
+If a stage fails or you want to iterate:
+
+```elixir
+reset_workflow(:feature)     # clear all work items
+run_workflow(:feature)       # start fresh
+```
+
+### Failure propagation
+
+Workflows are transactional. If a stage fails:
+
+1. The failed stage is marked `:failed`
+2. All downstream stages are `:blocked` (via dependency resolution)
+3. The workflow status becomes `:failed`
+
+Use `reset_workflow/1` to clear the failed state and try again.
+
+### Workflow lifecycle
+
+```
+defined --> running --> completed
+                    --> failed
+```
+
+A workflow is `:completed` when all stages reach `:done`. It is `:failed`
+when any stage is `:failed` or `:blocked`.
+
+## work_from_result
+
+Convert an agent's last response into a work item:
+
+```elixir
+ask(:planner, "What should we build?")
+work_from_result(:planner, :feature,
+  type: :code,
+  title: "Implement the feature")
+```
+
+The agent's response becomes the work item's spec. Useful for bridging
+direct interaction into board-driven execution.

--- a/lib/agent_workshop/workshop.ex
+++ b/lib/agent_workshop/workshop.ex
@@ -68,7 +68,7 @@ defmodule AgentWorkshop.Workshop do
 
   ## Architecture
 
-  The OTP Application (`AgentWorkshop.Application`) owns the full lifecycle:
+  The OTP Application owns the full lifecycle:
   ETS tables, registries, supervisors, and the EventLog. Workshop is the
   public IEx facade -- it reads and writes shared state but does not start
   or supervise any infrastructure. Call `configure/1` to set your backend;

--- a/mix.exs
+++ b/mix.exs
@@ -51,8 +51,53 @@ defmodule AgentWorkshop.MixProject do
 
   defp docs do
     [
-      main: "AgentWorkshop",
-      source_url: @source_url
+      main: "readme",
+      source_url: @source_url,
+      extras: [
+        "README.md",
+        "guides/getting-started.md",
+        "guides/orchestration-patterns.md",
+        "guides/work-board.md",
+        "guides/mcp-server.md",
+        "guides/configuration.md",
+        "CHANGELOG.md",
+        "LICENSE"
+      ],
+      groups_for_extras: [
+        Guides: ~r/guides\/.*/
+      ],
+      groups_for_modules: [
+        "Core API": [
+          AgentWorkshop,
+          AgentWorkshop.Workshop,
+          AgentWorkshop.Backend
+        ],
+        Backends: [
+          AgentWorkshop.Backends.Claude,
+          AgentWorkshop.Backends.Codex
+        ],
+        "Work Board": [
+          AgentWorkshop.Work,
+          AgentWorkshop.BoardWorker,
+          AgentWorkshop.Workflow
+        ],
+        "Agent Configuration": [
+          AgentWorkshop.Profiles,
+          AgentWorkshop.Skills,
+          AgentWorkshop.Budget
+        ],
+        Observability: [
+          AgentWorkshop.EventLog,
+          AgentWorkshop.PubSub,
+          AgentWorkshop.Telemetry
+        ],
+        Infrastructure: [
+          AgentWorkshop.Store,
+          AgentWorkshop.Scheduler,
+          AgentWorkshop.Persistence,
+          AgentWorkshop.GitContext
+        ]
+      ]
     ]
   end
 
@@ -60,7 +105,7 @@ defmodule AgentWorkshop.MixProject do
     [
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url},
-      files: ~w(lib skills AGENTS.md mix.exs README.md LICENSE .formatter.exs),
+      files: ~w(lib skills examples AGENTS.md mix.exs README.md LICENSE .formatter.exs),
       maintainers: ["Josh Rotenberg"]
     ]
   end


### PR DESCRIPTION
## Summary
- Add 5 guides for hexdocs: Getting Started, Orchestration Patterns, Work Board & Workflows, MCP Server, Configuration Reference
- Update ex_doc config with 7 module groups and guides extras section
- Add `examples/` to hex package files
- Update README with workflows section and `~> 0.3` version
- Fix doc warning for hidden module reference

Closes #78

## Test plan
- [x] `mix docs` builds with 0 warnings
- [x] All 5 guides render as HTML in `doc/`
- [x] Sidebar shows module groups (Core API, Backends, Work Board, etc.) and Guides section
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean
- [ ] CI passes