### PR TITLE
fix: Burrito release config and graceful Node.start fallback

### DIFF
--- a/lib/agent_workshop/application.ex
+++ b/lib/agent_workshop/application.ex
@@ -111,14 +111,14 @@ defmodule AgentWorkshop.Application do
 
   # Client mode: connect to daemon via erpc, run CLI command, exit
   defp start_client(args) do
-    client = :"aw_cli_#{System.system_time(:nanosecond)}@localhost"
-    Node.start(client, :shortnames)
-    Node.set_cookie(@cookie)
-
     mode =
-      case Node.connect(@daemon_node) do
-        true -> :remote
-        false -> :local
+      with client <- :"aw_cli_#{System.system_time(:nanosecond)}@localhost",
+           {:ok, _} <- Node.start(client, :shortnames),
+           true <- Node.set_cookie(@cookie) || true,
+           true <- Node.connect(@daemon_node) do
+        :remote
+      else
+        _ -> :local
       end
 
     if mode == :local do

--- a/mix.exs
+++ b/mix.exs
@@ -106,22 +106,18 @@ defmodule AgentWorkshop.MixProject do
   end
 
   defp releases do
-    if Code.ensure_loaded?(Burrito) do
-      [
-        aw: [
-          steps: [:assemble, &Burrito.wrap/1],
-          burrito: [
-            targets: [
-              macos: [os: :darwin, cpu: :x86_64],
-              macos_m1: [os: :darwin, cpu: :aarch64],
-              linux: [os: :linux, cpu: :x86_64]
-            ]
+    [
+      aw: [
+        steps: [:assemble, &Burrito.wrap/1],
+        burrito: [
+          targets: [
+            macos: [os: :darwin, cpu: :x86_64],
+            macos_m1: [os: :darwin, cpu: :aarch64],
+            linux: [os: :linux, cpu: :x86_64]
           ]
         ]
       ]
-    else
-      []
-    end
+    ]
   end
 
   defp package do


### PR DESCRIPTION
## Summary
- Remove `Code.ensure_loaded?(Burrito)` guard on release config (Burrito isn't available at mix.exs evaluation time)
- Handle `Node.start` failure gracefully in client mode -- falls back to local instead of crashing
- Fixes the binary build (`mix release aw`) and `aw --help` / `aw status` etc.

## Test plan
- [x] `mix release aw` builds successfully
- [x] `./burrito_out/aw_macos_m1 --help` shows command list
- [x] `./burrito_out/aw_macos_m1 status` works in local mode
- [x] `./burrito_out/aw_macos_m1 board` works in local mode
- [ ] CI passes